### PR TITLE
One rule to rule them all

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,6 +13,7 @@
         "Install.Import",
         "Install.Initializer",
         "Install.InitializerCmd",
+        "Install.Rule",
         "Install.Subscription",
         "Install.Type",
         "Install.TypeVariant"

--- a/elm.json
+++ b/elm.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "version": "12.0.4",
     "exposed-modules": [
+        "Install",
         "Install.ClauseInCase",
         "Install.ElementToList",
         "Install.FieldInTypeAlias",
@@ -13,7 +14,6 @@
         "Install.Import",
         "Install.Initializer",
         "Install.InitializerCmd",
-        "Install.Rule",
         "Install.Subscription",
         "Install.Type",
         "Install.TypeVariant"

--- a/preview/elm.json
+++ b/preview/elm.json
@@ -10,9 +10,9 @@
             "elm/core": "1.0.5",
             "elm/regex": "1.0.0",
             "elmcraft/core-extra": "2.0.0",
-            "jfmengels/elm-review": "2.13.2",
+            "jfmengels/elm-review": "2.14.0",
             "pzp1997/assoc-list": "1.0.0",
-            "stil4m/elm-syntax": "7.3.2"
+            "stil4m/elm-syntax": "7.3.3"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -285,8 +285,9 @@ configAuthBackend adminConfig =
             , { field = "log", value = "[]" }
             ]
             |> Install.initializer
+        , Subscription.config "Backend" [ "Lamdera.onConnect OnConnected" ]
+            |> Install.subscription
         ]
-    , Subscription.makeRule "Backend" [ "Lamdera.onConnect OnConnected" ]
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -220,6 +220,8 @@ configAuthFrontend =
             |> Install.insertClauseInCase
         , Initializer.config "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
             |> Install.initializer
+        , Install.Type.config "Types" "BackendDataStatus" [ "Sunny", "LoadedBackendData", "Spell String Int" ]
+            |> Install.addType
         ]
     , TypeVariant.makeRule "Types"
         "ToFrontend"
@@ -235,7 +237,6 @@ configAuthFrontend =
         , "GotUserDictionary (Dict.Dict User.EmailString User.User)"
         , "GotMessage String"
         ]
-    , Install.Type.makeRule "Types" "BackendDataStatus" [ "Sunny", "LoadedBackendData", "Spell String Int" ]
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -68,11 +68,12 @@ configAtmospheric =
             |> Install.insertClauseInCase
         , ClauseInCase.config "Backend" "update" "GotFastTick time" "( { model | time = time } , Cmd.none )"
             |> Install.insertClauseInCase
-        ]
-    , FieldInTypeAlias.makeRule "Types"
-        "BackendModel"
-        [ "randomAtmosphericNumbers : Maybe (List Int)"
-        , "time : Time.Posix"
+        , FieldInTypeAlias.config "Types"
+            "BackendModel"
+            [ "randomAtmosphericNumbers : Maybe (List Int)"
+            , "time : Time.Posix"
+            ]
+            |> Install.insertFieldInTypeAlias
         ]
     , TypeVariant.makeRule "Types"
         "BackendMsg"
@@ -100,13 +101,15 @@ configUsers =
             |> Install.addImport
         , Import.qualified "Frontend" [ "Dict" ]
             |> Install.addImport
+        , FieldInTypeAlias.config "Types"
+            "BackendModel"
+            [ "users: Dict.Dict User.EmailString User.User"
+            , "userNameToEmailString : Dict.Dict User.Username User.EmailString"
+            ]
+            |> Install.insertFieldInTypeAlias
+        , FieldInTypeAlias.config "Types" "LoadedModel" [ "users : Dict.Dict User.EmailString User.User" ]
+            |> Install.insertFieldInTypeAlias
         ]
-    , FieldInTypeAlias.makeRule "Types"
-        "BackendModel"
-        [ "users: Dict.Dict User.EmailString User.User"
-        , "userNameToEmailString : Dict.Dict User.Username User.EmailString"
-        ]
-    , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "users : Dict.Dict User.EmailString User.User" ]
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "users", value = "Dict.empty" } ]
     ]
 
@@ -122,11 +125,12 @@ configMagicLinkMinimal =
             |> Install.addImport
         , ClauseInCase.config "Backend" "updateFromFrontend" "AuthToBackend authMsg" "Auth.Flow.updateFromFrontend (MagicLink.Auth.backendConfig model) clientId sessionId authMsg model"
             |> Install.insertClauseInCase
+        , FieldInTypeAlias.config "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
+            |> Install.insertFieldInTypeAlias
         ]
     , TypeVariant.makeRule "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
     , TypeVariant.makeRule "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
     , TypeVariant.makeRule "Types" "ToBackend" [ "AuthToBackend Auth.Common.ToBackend" ]
-    , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , TypeVariant.makeRule "Types"
         "ToFrontend"
@@ -145,6 +149,21 @@ configAuthTypes =
     [ Install.rule "REPLACEME"
         [ Import.qualified "Types" [ "AssocList", "Auth.Common", "LocalUUID", "MagicLink.Types", "Session" ]
             |> Install.addImport
+        , FieldInTypeAlias.config "Types"
+            "BackendModel"
+            [ "localUuidData : Maybe LocalUUID.Data"
+            , "pendingAuths : Dict Lamdera.SessionId Auth.Common.PendingAuth"
+            , "pendingEmailAuths : Dict Lamdera.SessionId Auth.Common.PendingEmailAuth"
+            , "sessions : Dict SessionId Auth.Common.UserInfo"
+            , "secretCounter : Int"
+            , "sessionDict : AssocList.Dict SessionId String"
+            , "pendingLogins : MagicLink.Types.PendingLogins"
+            , "log : MagicLink.Types.Log"
+            , "sessionInfo : Session.SessionInfo"
+            ]
+            |> Install.insertFieldInTypeAlias
+        , FieldInTypeAlias.config "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
+            |> Install.insertFieldInTypeAlias
         ]
     , TypeVariant.makeRule "Types"
         "FrontendMsg"
@@ -159,18 +178,6 @@ configAuthTypes =
         , "AutoLogin SessionId User.SignInData"
         , "OnConnected SessionId ClientId"
         ]
-    , FieldInTypeAlias.makeRule "Types"
-        "BackendModel"
-        [ "localUuidData : Maybe LocalUUID.Data"
-        , "pendingAuths : Dict Lamdera.SessionId Auth.Common.PendingAuth"
-        , "pendingEmailAuths : Dict Lamdera.SessionId Auth.Common.PendingEmailAuth"
-        , "sessions : Dict SessionId Auth.Common.UserInfo"
-        , "secretCounter : Int"
-        , "sessionDict : AssocList.Dict SessionId String"
-        , "pendingLogins : MagicLink.Types.PendingLogins"
-        , "log : MagicLink.Types.Log"
-        , "sessionInfo : Session.SessionInfo"
-        ]
     , TypeVariant.makeRule "Types"
         "ToBackend"
         [ "AuthToBackend Auth.Common.ToBackend"
@@ -178,7 +185,6 @@ configAuthTypes =
         , "RequestSignUp String String String"
         , "GetUserDictionary"
         ]
-    , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -18,6 +18,7 @@ import Install.Function.ReplaceFunction as ReplaceFunction
 import Install.Import as Import exposing (module_, qualified, withAlias, withExposedValues)
 import Install.Initializer as Initializer
 import Install.InitializerCmd as InitializerCmd
+import Install.Rule
 import Install.Subscription as Subscription
 import Install.Type
 import Install.TypeVariant as TypeVariant
@@ -55,9 +56,13 @@ configAll adminConfig =
 
 configAtmospheric : List Rule
 configAtmospheric =
-    [ -- Add fields randomAtmosphericNumbers and time to BackendModel
-      Import.qualified "Types" [ "Http" ] |> Import.makeRule
-    , Import.qualified "Backend" [ "Atmospheric", "Dict", "Time", "Task", "MagicLink.Helper", "MagicLink.Backend", "MagicLink.Auth" ] |> Import.makeRule
+    [ Install.Rule.rule "AddAtmospheric"
+        [ -- Add fields randomAtmosphericNumbers and time to BackendModel
+          Import.qualified "Types" [ "Http" ]
+            |> Install.Rule.addImport
+        , Import.qualified "Backend" [ "Atmospheric", "Dict", "Time", "Task", "MagicLink.Helper", "MagicLink.Backend", "MagicLink.Auth" ]
+            |> Install.Rule.addImport
+        ]
     , FieldInTypeAlias.makeRule "Types"
         "BackendModel"
         [ "randomAtmosphericNumbers : Maybe (List Int)"
@@ -78,34 +83,41 @@ configAtmospheric =
 
 configUsers : List Rule
 configUsers =
-    [ Import.qualified "Types" [ "User" ] |> Import.makeRule
-    , Import.config "Types" [ module_ "Dict" |> withExposedValues [ "Dict" ] ] |> Import.makeRule
+    [ Install.Rule.rule "REPLACEME"
+        [ Import.qualified "Types" [ "User" ] |> Install.Rule.addImport
+        , Import.config "Types" [ module_ "Dict" |> withExposedValues [ "Dict" ] ] |> Install.Rule.addImport
+        ]
     , FieldInTypeAlias.makeRule "Types"
         "BackendModel"
         [ "users: Dict.Dict User.EmailString User.User"
         , "userNameToEmailString : Dict.Dict User.Username User.EmailString"
         ]
     , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "users : Dict.Dict User.EmailString User.User" ]
-    , Import.qualified "Backend" [ "Time", "Task", "LocalUUID" ] |> Import.makeRule
-    , Import.config "Backend"
-        [ module_ "MagicLink.Helper" |> withAlias "Helper"
-        , module_ "Dict" |> withExposedValues [ "Dict" ]
+    , Install.Rule.rule "REPLACEME"
+        [ Import.qualified "Backend" [ "Time", "Task", "LocalUUID" ] |> Install.Rule.addImport
+        , Import.config "Backend"
+            [ module_ "MagicLink.Helper" |> withAlias "Helper"
+            , module_ "Dict" |> withExposedValues [ "Dict" ]
+            ]
+            |> Install.Rule.addImport
+        , Import.qualified "Frontend" [ "Dict" ]
+            |> Install.Rule.addImport
         ]
-        |> Import.makeRule
-    , Import.qualified "Frontend" [ "Dict" ] |> Import.makeRule
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "users", value = "Dict.empty" } ]
     ]
 
 
 configMagicLinkMinimal : List Rule
 configMagicLinkMinimal =
-    [ Import.qualified "Types" [ "Auth.Common", "MagicLink.Types" ] |> Import.makeRule
+    [ Install.Rule.rule "REPLACEME"
+        [ Import.qualified "Types" [ "Auth.Common", "MagicLink.Types" ] |> Install.Rule.addImport
+        , Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Install.Rule.addImport
+        , Import.qualified "Backend" [ "Auth.Flow" ] |> Install.Rule.addImport
+        ]
     , TypeVariant.makeRule "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
     , TypeVariant.makeRule "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
     , TypeVariant.makeRule "Types" "ToBackend" [ "AuthToBackend Auth.Common.ToBackend" ]
     , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
-    , Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Import.makeRule
-    , Import.qualified "Backend" [ "Auth.Flow" ] |> Import.makeRule
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , TypeVariant.makeRule "Types"
         "ToFrontend"
@@ -122,7 +134,9 @@ configMagicLinkMinimal =
 
 configAuthTypes : List Rule
 configAuthTypes =
-    [ Import.qualified "Types" [ "AssocList", "Auth.Common", "LocalUUID", "MagicLink.Types", "Session" ] |> Import.makeRule
+    [ Install.Rule.rule "REPLACEME"
+        [ Import.qualified "Types" [ "AssocList", "Auth.Common", "LocalUUID", "MagicLink.Types", "Session" ] |> Install.Rule.addImport
+        ]
     , TypeVariant.makeRule "Types"
         "FrontendMsg"
         [ "SignInUser User.SignInData"
@@ -161,7 +175,9 @@ configAuthTypes =
 
 configAuthFrontend : List Rule
 configAuthFrontend =
-    [ Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Import.makeRule
+    [ Install.Rule.rule "REPLACEME"
+        [ Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Install.Rule.addImport
+        ]
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , ClauseInCase.config "Frontend" "updateFromBackendLoaded" "AuthToFrontend authToFrontendMsg" "MagicLink.Auth.updateFromBackend authToFrontendMsg model.magicLinkModel |> Tuple.mapFirst (\\magicLinkModel -> { model | magicLinkModel = magicLinkModel })"
         |> ClauseInCase.withInsertAtBeginning
@@ -205,16 +221,18 @@ configAuthBackend adminConfig =
     , ClauseInCase.config "Backend" "update" "AutoLogin sessionId loginData" "( model, Lamdera.sendToFrontend sessionId (AuthToFrontend <| Auth.Common.AuthSignInWithTokenResponse <| Ok <| loginData) )" |> ClauseInCase.makeRule
     , ClauseInCase.config "Backend" "update" "OnConnected sessionId clientId" "( model, Reconnect.connect model sessionId clientId )" |> ClauseInCase.makeRule
     , ClauseInCase.config "Backend" "update" "ClientConnected sessionId clientId" "( model, Reconnect.connect model sessionId clientId )" |> ClauseInCase.makeRule
-    , Import.qualified "Backend"
-        [ "AssocList"
-        , "Auth.Common"
-        , "Auth.Flow"
-        , "MagicLink.Auth"
-        , "MagicLink.Backend"
-        , "Reconnect"
-        , "User"
+    , Install.Rule.rule "REPLACEME"
+        [ Import.qualified "Backend"
+            [ "AssocList"
+            , "Auth.Common"
+            , "Auth.Flow"
+            , "MagicLink.Auth"
+            , "MagicLink.Backend"
+            , "Reconnect"
+            , "User"
+            ]
+            |> Install.Rule.addImport
         ]
-        |> Import.makeRule
     , Initializer.makeRule "Backend"
         "init"
         [ { field = "randomAtmosphericNumbers", value = "Just [ 235880, 700828, 253400, 602641 ]" }
@@ -260,7 +278,9 @@ addPage : ( String, String ) -> List Rule
 addPage ( pageTitle, routeName ) =
     [ TypeVariant.makeRule "Route" "Route" [ pageTitle ++ "Route" ]
     , ClauseInCase.config "View.Main" "loadedView" (pageTitle ++ "Route") ("generic model Pages." ++ pageTitle ++ ".view") |> ClauseInCase.makeRule
-    , Import.qualified "View.Main" [ "Pages." ++ pageTitle ] |> Import.makeRule
+    , Install.Rule.rule "REPLACEME"
+        [ Import.qualified "View.Main" [ "Pages." ++ pageTitle ] |> Install.Rule.addImport
+        ]
     , ElementToList.makeRule "Route" "routesAndNames" [ "(" ++ pageTitle ++ "Route, \"" ++ routeName ++ "\")" ]
     ]
 
@@ -271,7 +291,9 @@ configView =
     , ClauseInCase.config "View.Main" "loadedView" "NotesRoute" "generic model Pages.Notes.view" |> ClauseInCase.makeRule
     , ClauseInCase.config "View.Main" "loadedView" "SignInRoute" "generic model (\\model_ -> Pages.SignIn.view Types.LiftMsg model_.magicLinkModel |> Element.map Types.AuthFrontendMsg)" |> ClauseInCase.makeRule
     , ClauseInCase.config "View.Main" "loadedView" "CounterPageRoute" "generic model Pages.Counter.view" |> ClauseInCase.makeRule
-    , Import.qualified "View.Main" [ "MagicLink.Helper", "Pages.Counter", "Pages.SignIn", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes", "User" ] |> Import.makeRule
+    , Install.Rule.rule "AddConfig"
+        [ Import.qualified "View.Main" [ "MagicLink.Helper", "Pages.Counter", "Pages.SignIn", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes", "User" ] |> Install.Rule.addImport
+        ]
     , ReplaceFunction.config "View.Main" "headerRow" headerRow |> ReplaceFunction.makeRule
     , ReplaceFunction.config "View.Main" "makeLinks" makeLinks |> ReplaceFunction.makeRule
     ]

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -109,8 +109,9 @@ configUsers =
             |> Install.insertFieldInTypeAlias
         , FieldInTypeAlias.config "Types" "LoadedModel" [ "users : Dict.Dict User.EmailString User.User" ]
             |> Install.insertFieldInTypeAlias
+        , Initializer.config "Frontend" "initLoaded" [ { field = "users", value = "Dict.empty" } ]
+            |> Install.initializer
         ]
-    , Initializer.makeRule "Frontend" "initLoaded" [ { field = "users", value = "Dict.empty" } ]
     ]
 
 
@@ -127,11 +128,12 @@ configMagicLinkMinimal =
             |> Install.insertClauseInCase
         , FieldInTypeAlias.config "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
             |> Install.insertFieldInTypeAlias
+        , Initializer.config "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
+            |> Install.initializer
         ]
     , TypeVariant.makeRule "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
     , TypeVariant.makeRule "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
     , TypeVariant.makeRule "Types" "ToBackend" [ "AuthToBackend Auth.Common.ToBackend" ]
-    , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , TypeVariant.makeRule "Types"
         "ToFrontend"
         [ "AuthToFrontend Auth.Common.ToFrontend"
@@ -215,8 +217,9 @@ configAuthFrontend =
             |> Install.insertClauseInCase
         , ClauseInCase.config "Frontend" "updateLoaded" "LiftMsg _" "( model, Cmd.none )"
             |> Install.insertClauseInCase
+        , Initializer.config "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
+            |> Install.initializer
         ]
-    , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , TypeVariant.makeRule "Types"
         "ToFrontend"
         [ "AuthToFrontend Auth.Common.ToFrontend"
@@ -264,22 +267,23 @@ configAuthBackend adminConfig =
             |> Install.insertClauseInCase
         , ClauseInCase.config "Backend" "updateFromFrontend" "GetUserDictionary" "( model, Lamdera.sendToFrontend clientId (GotUserDictionary model.users) )"
             |> Install.insertClauseInCase
-        ]
-    , Initializer.makeRule "Backend"
-        "init"
-        [ { field = "randomAtmosphericNumbers", value = "Just [ 235880, 700828, 253400, 602641 ]" }
-        , { field = "time", value = "Time.millisToPosix 0" }
-        , { field = "sessions", value = "Dict.empty" }
-        , { field = "userNameToEmailString", value = "Dict.fromList [ (\"jxxcarlson\", \"jxxcarlson@gmail.com\") ]" }
-        , { field = "users", value = "MagicLink.Helper.initialUserDictionary " ++ stringifyAdminConfig adminConfig }
-        , { field = "sessionInfo", value = "Dict.empty" }
-        , { field = "pendingAuths", value = "Dict.empty" }
-        , { field = "localUuidData", value = "LocalUUID.initFrom4List [ 235880, 700828, 253400, 602641 ]" }
-        , { field = "pendingEmailAuths", value = "Dict.empty" }
-        , { field = "secretCounter", value = "0" }
-        , { field = "sessionDict", value = "AssocList.empty" }
-        , { field = "pendingLogins", value = "AssocList.empty" }
-        , { field = "log", value = "[]" }
+        , Initializer.config "Backend"
+            "init"
+            [ { field = "randomAtmosphericNumbers", value = "Just [ 235880, 700828, 253400, 602641 ]" }
+            , { field = "time", value = "Time.millisToPosix 0" }
+            , { field = "sessions", value = "Dict.empty" }
+            , { field = "userNameToEmailString", value = "Dict.fromList [ (\"jxxcarlson\", \"jxxcarlson@gmail.com\") ]" }
+            , { field = "users", value = "MagicLink.Helper.initialUserDictionary " ++ stringifyAdminConfig adminConfig }
+            , { field = "sessionInfo", value = "Dict.empty" }
+            , { field = "pendingAuths", value = "Dict.empty" }
+            , { field = "localUuidData", value = "LocalUUID.initFrom4List [ 235880, 700828, 253400, 602641 ]" }
+            , { field = "pendingEmailAuths", value = "Dict.empty" }
+            , { field = "secretCounter", value = "0" }
+            , { field = "sessionDict", value = "AssocList.empty" }
+            , { field = "pendingLogins", value = "AssocList.empty" }
+            , { field = "log", value = "[]" }
+            ]
+            |> Install.initializer
         ]
     , Subscription.makeRule "Backend" [ "Lamdera.onConnect OnConnected" ]
     ]

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -74,6 +74,8 @@ configAtmospheric =
             , "time : Time.Posix"
             ]
             |> Install.insertFieldInTypeAlias
+        , InitializerCmd.config "Backend" "init" [ "Time.now |> Task.perform GotFastTick", "MagicLink.Helper.getAtmosphericRandomNumbers" ]
+            |> Install.initializerCmd
         ]
     , TypeVariant.makeRule "Types"
         "BackendMsg"
@@ -81,7 +83,6 @@ configAtmospheric =
         , "SetLocalUuidStuff (List Int)"
         , "GotFastTick Time.Posix"
         ]
-    , InitializerCmd.makeRule "Backend" "init" [ "Time.now |> Task.perform GotFastTick", "MagicLink.Helper.getAtmosphericRandomNumbers" ]
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -89,7 +89,7 @@ configAtmospheric =
 
 configUsers : List Rule
 configUsers =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "ConfigUsers"
         [ Import.qualified "Types" [ "User" ]
             |> Install.addImport
         , Import.config "Types" [ module_ "Dict" |> withExposedValues [ "Dict" ] ]
@@ -119,7 +119,7 @@ configUsers =
 
 configMagicLinkMinimal : List Rule
 configMagicLinkMinimal =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "AddMagicLink"
         [ Import.qualified "Types" [ "Auth.Common", "MagicLink.Types" ]
             |> Install.addImport
         , Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ]
@@ -154,7 +154,7 @@ configMagicLinkMinimal =
 
 configAuthTypes : List Rule
 configAuthTypes =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "ConfigAuth"
         [ Import.qualified "Types" [ "AssocList", "Auth.Common", "LocalUUID", "MagicLink.Types", "Session" ]
             |> Install.addImport
         , FieldInTypeAlias.config "Types"
@@ -201,7 +201,7 @@ configAuthTypes =
 
 configAuthFrontend : List Rule
 configAuthFrontend =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "ConfigAuthFrontend"
         [ Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ]
             |> Install.addImport
         , ReplaceFunction.replace "Frontend" "tryLoading" tryLoading2
@@ -251,7 +251,7 @@ configAuthFrontend =
 
 configAuthBackend : { fullname : String, username : String, email : String } -> List Rule
 configAuthBackend adminConfig =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "ConfigAuthBackend"
         [ ClauseInCase.config "Backend" "update" "AuthBackendMsg authMsg" "Auth.Flow.backendUpdate (MagicLink.Auth.backendConfig model) authMsg"
             |> Install.insertClauseInCase
         , ClauseInCase.config "Backend" "update" "AutoLogin sessionId loginData" "( model, Lamdera.sendToFrontend sessionId (AuthToFrontend <| Auth.Common.AuthSignInWithTokenResponse <| Ok <| loginData) )"
@@ -303,7 +303,7 @@ configAuthBackend adminConfig =
 
 configRoute : List Rule
 configRoute =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "AddRoute"
         [ -- ROUTE
           TypeVariant.config "Route" "Route" [ "NotesRoute", "SignInRoute", "AdminRoute" ]
             |> Install.addTypeVariant
@@ -327,7 +327,7 @@ addPages pageData =
 
 addPage : ( String, String ) -> List Rule
 addPage ( pageTitle, routeName ) =
-    [ Install.rule "REPLACEME"
+    [ Install.rule "AddPage"
         [ TypeVariant.config "Route" "Route" [ pageTitle ++ "Route" ]
             |> Install.addTypeVariant
         , ClauseInCase.config "View.Main" "loadedView" (pageTitle ++ "Route") ("generic model Pages." ++ pageTitle ++ ".view")

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -86,15 +86,7 @@ configUsers =
     [ Install.Rule.rule "REPLACEME"
         [ Import.qualified "Types" [ "User" ] |> Install.Rule.addImport
         , Import.config "Types" [ module_ "Dict" |> withExposedValues [ "Dict" ] ] |> Install.Rule.addImport
-        ]
-    , FieldInTypeAlias.makeRule "Types"
-        "BackendModel"
-        [ "users: Dict.Dict User.EmailString User.User"
-        , "userNameToEmailString : Dict.Dict User.Username User.EmailString"
-        ]
-    , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "users : Dict.Dict User.EmailString User.User" ]
-    , Install.Rule.rule "REPLACEME"
-        [ Import.qualified "Backend" [ "Time", "Task", "LocalUUID" ] |> Install.Rule.addImport
+        , Import.qualified "Backend" [ "Time", "Task", "LocalUUID" ] |> Install.Rule.addImport
         , Import.config "Backend"
             [ module_ "MagicLink.Helper" |> withAlias "Helper"
             , module_ "Dict" |> withExposedValues [ "Dict" ]
@@ -103,6 +95,12 @@ configUsers =
         , Import.qualified "Frontend" [ "Dict" ]
             |> Install.Rule.addImport
         ]
+    , FieldInTypeAlias.makeRule "Types"
+        "BackendModel"
+        [ "users: Dict.Dict User.EmailString User.User"
+        , "userNameToEmailString : Dict.Dict User.Username User.EmailString"
+        ]
+    , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "users : Dict.Dict User.EmailString User.User" ]
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "users", value = "Dict.empty" } ]
     ]
 
@@ -261,7 +259,13 @@ configRoute : List Rule
 configRoute =
     [ -- ROUTE
       TypeVariant.makeRule "Route" "Route" [ "NotesRoute", "SignInRoute", "AdminRoute" ]
-    , ElementToList.makeRule "Route" "routesAndNames" [ "(NotesRoute, \"notes\")", "(SignInRoute, \"signin\")", "(AdminRoute, \"admin\")" ]
+    , Install.Rule.rule "REPLACEME"
+        [ ElementToList.add
+            "Route"
+            "routesAndNames"
+            [ "(NotesRoute, \"notes\")", "(SignInRoute, \"signin\")", "(AdminRoute, \"admin\")" ]
+            |> Install.Rule.addElementToList
+        ]
     ]
 
 
@@ -279,9 +283,14 @@ addPage ( pageTitle, routeName ) =
     [ TypeVariant.makeRule "Route" "Route" [ pageTitle ++ "Route" ]
     , ClauseInCase.config "View.Main" "loadedView" (pageTitle ++ "Route") ("generic model Pages." ++ pageTitle ++ ".view") |> ClauseInCase.makeRule
     , Install.Rule.rule "REPLACEME"
-        [ Import.qualified "View.Main" [ "Pages." ++ pageTitle ] |> Install.Rule.addImport
+        [ Import.qualified "View.Main" [ "Pages." ++ pageTitle ]
+            |> Install.Rule.addImport
+        , ElementToList.add
+            "Route"
+            "routesAndNames"
+            [ "(" ++ pageTitle ++ "Route, \"" ++ routeName ++ "\")" ]
+            |> Install.Rule.addElementToList
         ]
-    , ElementToList.makeRule "Route" "routesAndNames" [ "(" ++ pageTitle ++ "Route, \"" ++ routeName ++ "\")" ]
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -11,6 +11,7 @@ when inside the directory containing this file.
 
 -}
 
+import Install
 import Install.ClauseInCase as ClauseInCase
 import Install.ElementToList as ElementToList
 import Install.FieldInTypeAlias as FieldInTypeAlias
@@ -18,7 +19,6 @@ import Install.Function.ReplaceFunction as ReplaceFunction
 import Install.Import as Import exposing (module_, qualified, withAlias, withExposedValues)
 import Install.Initializer as Initializer
 import Install.InitializerCmd as InitializerCmd
-import Install.Rule
 import Install.Subscription as Subscription
 import Install.Type
 import Install.TypeVariant as TypeVariant
@@ -56,12 +56,12 @@ configAll adminConfig =
 
 configAtmospheric : List Rule
 configAtmospheric =
-    [ Install.Rule.rule "AddAtmospheric"
+    [ Install.rule "AddAtmospheric"
         [ -- Add fields randomAtmosphericNumbers and time to BackendModel
           Import.qualified "Types" [ "Http" ]
-            |> Install.Rule.addImport
+            |> Install.addImport
         , Import.qualified "Backend" [ "Atmospheric", "Dict", "Time", "Task", "MagicLink.Helper", "MagicLink.Backend", "MagicLink.Auth" ]
-            |> Install.Rule.addImport
+            |> Install.addImport
         ]
     , FieldInTypeAlias.makeRule "Types"
         "BackendModel"
@@ -83,17 +83,20 @@ configAtmospheric =
 
 configUsers : List Rule
 configUsers =
-    [ Install.Rule.rule "REPLACEME"
-        [ Import.qualified "Types" [ "User" ] |> Install.Rule.addImport
-        , Import.config "Types" [ module_ "Dict" |> withExposedValues [ "Dict" ] ] |> Install.Rule.addImport
-        , Import.qualified "Backend" [ "Time", "Task", "LocalUUID" ] |> Install.Rule.addImport
+    [ Install.rule "REPLACEME"
+        [ Import.qualified "Types" [ "User" ]
+            |> Install.addImport
+        , Import.config "Types" [ module_ "Dict" |> withExposedValues [ "Dict" ] ]
+            |> Install.addImport
+        , Import.qualified "Backend" [ "Time", "Task", "LocalUUID" ]
+            |> Install.addImport
         , Import.config "Backend"
             [ module_ "MagicLink.Helper" |> withAlias "Helper"
             , module_ "Dict" |> withExposedValues [ "Dict" ]
             ]
-            |> Install.Rule.addImport
+            |> Install.addImport
         , Import.qualified "Frontend" [ "Dict" ]
-            |> Install.Rule.addImport
+            |> Install.addImport
         ]
     , FieldInTypeAlias.makeRule "Types"
         "BackendModel"
@@ -107,10 +110,13 @@ configUsers =
 
 configMagicLinkMinimal : List Rule
 configMagicLinkMinimal =
-    [ Install.Rule.rule "REPLACEME"
-        [ Import.qualified "Types" [ "Auth.Common", "MagicLink.Types" ] |> Install.Rule.addImport
-        , Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Install.Rule.addImport
-        , Import.qualified "Backend" [ "Auth.Flow" ] |> Install.Rule.addImport
+    [ Install.rule "REPLACEME"
+        [ Import.qualified "Types" [ "Auth.Common", "MagicLink.Types" ]
+            |> Install.addImport
+        , Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ]
+            |> Install.addImport
+        , Import.qualified "Backend" [ "Auth.Flow" ]
+            |> Install.addImport
         ]
     , TypeVariant.makeRule "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
     , TypeVariant.makeRule "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
@@ -132,8 +138,9 @@ configMagicLinkMinimal =
 
 configAuthTypes : List Rule
 configAuthTypes =
-    [ Install.Rule.rule "REPLACEME"
-        [ Import.qualified "Types" [ "AssocList", "Auth.Common", "LocalUUID", "MagicLink.Types", "Session" ] |> Install.Rule.addImport
+    [ Install.rule "REPLACEME"
+        [ Import.qualified "Types" [ "AssocList", "Auth.Common", "LocalUUID", "MagicLink.Types", "Session" ]
+            |> Install.addImport
         ]
     , TypeVariant.makeRule "Types"
         "FrontendMsg"
@@ -173,8 +180,9 @@ configAuthTypes =
 
 configAuthFrontend : List Rule
 configAuthFrontend =
-    [ Install.Rule.rule "REPLACEME"
-        [ Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Install.Rule.addImport
+    [ Install.rule "REPLACEME"
+        [ Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ]
+            |> Install.addImport
         ]
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , ClauseInCase.config "Frontend" "updateFromBackendLoaded" "AuthToFrontend authToFrontendMsg" "MagicLink.Auth.updateFromBackend authToFrontendMsg model.magicLinkModel |> Tuple.mapFirst (\\magicLinkModel -> { model | magicLinkModel = magicLinkModel })"
@@ -219,7 +227,7 @@ configAuthBackend adminConfig =
     , ClauseInCase.config "Backend" "update" "AutoLogin sessionId loginData" "( model, Lamdera.sendToFrontend sessionId (AuthToFrontend <| Auth.Common.AuthSignInWithTokenResponse <| Ok <| loginData) )" |> ClauseInCase.makeRule
     , ClauseInCase.config "Backend" "update" "OnConnected sessionId clientId" "( model, Reconnect.connect model sessionId clientId )" |> ClauseInCase.makeRule
     , ClauseInCase.config "Backend" "update" "ClientConnected sessionId clientId" "( model, Reconnect.connect model sessionId clientId )" |> ClauseInCase.makeRule
-    , Install.Rule.rule "REPLACEME"
+    , Install.rule "REPLACEME"
         [ Import.qualified "Backend"
             [ "AssocList"
             , "Auth.Common"
@@ -229,7 +237,7 @@ configAuthBackend adminConfig =
             , "Reconnect"
             , "User"
             ]
-            |> Install.Rule.addImport
+            |> Install.addImport
         ]
     , Initializer.makeRule "Backend"
         "init"
@@ -259,12 +267,12 @@ configRoute : List Rule
 configRoute =
     [ -- ROUTE
       TypeVariant.makeRule "Route" "Route" [ "NotesRoute", "SignInRoute", "AdminRoute" ]
-    , Install.Rule.rule "REPLACEME"
+    , Install.rule "REPLACEME"
         [ ElementToList.add
             "Route"
             "routesAndNames"
             [ "(NotesRoute, \"notes\")", "(SignInRoute, \"signin\")", "(AdminRoute, \"admin\")" ]
-            |> Install.Rule.addElementToList
+            |> Install.addElementToList
         ]
     ]
 
@@ -282,14 +290,14 @@ addPage : ( String, String ) -> List Rule
 addPage ( pageTitle, routeName ) =
     [ TypeVariant.makeRule "Route" "Route" [ pageTitle ++ "Route" ]
     , ClauseInCase.config "View.Main" "loadedView" (pageTitle ++ "Route") ("generic model Pages." ++ pageTitle ++ ".view") |> ClauseInCase.makeRule
-    , Install.Rule.rule "REPLACEME"
+    , Install.rule "REPLACEME"
         [ Import.qualified "View.Main" [ "Pages." ++ pageTitle ]
-            |> Install.Rule.addImport
+            |> Install.addImport
         , ElementToList.add
             "Route"
             "routesAndNames"
             [ "(" ++ pageTitle ++ "Route, \"" ++ routeName ++ "\")" ]
-            |> Install.Rule.addElementToList
+            |> Install.addElementToList
         ]
     ]
 
@@ -300,8 +308,9 @@ configView =
     , ClauseInCase.config "View.Main" "loadedView" "NotesRoute" "generic model Pages.Notes.view" |> ClauseInCase.makeRule
     , ClauseInCase.config "View.Main" "loadedView" "SignInRoute" "generic model (\\model_ -> Pages.SignIn.view Types.LiftMsg model_.magicLinkModel |> Element.map Types.AuthFrontendMsg)" |> ClauseInCase.makeRule
     , ClauseInCase.config "View.Main" "loadedView" "CounterPageRoute" "generic model Pages.Counter.view" |> ClauseInCase.makeRule
-    , Install.Rule.rule "AddConfig"
-        [ Import.qualified "View.Main" [ "MagicLink.Helper", "Pages.Counter", "Pages.SignIn", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes", "User" ] |> Install.Rule.addImport
+    , Install.rule "AddConfig"
+        [ Import.qualified "View.Main" [ "MagicLink.Helper", "Pages.Counter", "Pages.SignIn", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes", "User" ]
+            |> Install.addImport
         ]
     , ReplaceFunction.config "View.Main" "headerRow" headerRow |> ReplaceFunction.makeRule
     , ReplaceFunction.config "View.Main" "makeLinks" makeLinks |> ReplaceFunction.makeRule

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -76,12 +76,13 @@ configAtmospheric =
             |> Install.insertFieldInTypeAlias
         , InitializerCmd.config "Backend" "init" [ "Time.now |> Task.perform GotFastTick", "MagicLink.Helper.getAtmosphericRandomNumbers" ]
             |> Install.initializerCmd
-        ]
-    , TypeVariant.makeRule "Types"
-        "BackendMsg"
-        [ "GotAtmosphericRandomNumbers (Result Http.Error String)"
-        , "SetLocalUuidStuff (List Int)"
-        , "GotFastTick Time.Posix"
+        , TypeVariant.config "Types"
+            "BackendMsg"
+            [ "GotAtmosphericRandomNumbers (Result Http.Error String)"
+            , "SetLocalUuidStuff (List Int)"
+            , "GotFastTick Time.Posix"
+            ]
+            |> Install.addTypeVariant
         ]
     ]
 
@@ -131,18 +132,22 @@ configMagicLinkMinimal =
             |> Install.insertFieldInTypeAlias
         , Initializer.config "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
             |> Install.initializer
-        ]
-    , TypeVariant.makeRule "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
-    , TypeVariant.makeRule "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
-    , TypeVariant.makeRule "Types" "ToBackend" [ "AuthToBackend Auth.Common.ToBackend" ]
-    , TypeVariant.makeRule "Types"
-        "ToFrontend"
-        [ "AuthToFrontend Auth.Common.ToFrontend"
-        , "AuthSuccess Auth.Common.UserInfo"
-        , "UserInfoMsg (Maybe Auth.Common.UserInfo)"
-        , "GetLoginTokenRateLimited"
-        , "RegistrationError String"
-        , "SignInError String"
+        , TypeVariant.config "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
+            |> Install.addTypeVariant
+        , TypeVariant.config "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
+            |> Install.addTypeVariant
+        , TypeVariant.config "Types" "ToBackend" [ "AuthToBackend Auth.Common.ToBackend" ]
+            |> Install.addTypeVariant
+        , TypeVariant.config "Types"
+            "ToFrontend"
+            [ "AuthToFrontend Auth.Common.ToFrontend"
+            , "AuthSuccess Auth.Common.UserInfo"
+            , "UserInfoMsg (Maybe Auth.Common.UserInfo)"
+            , "GetLoginTokenRateLimited"
+            , "RegistrationError String"
+            , "SignInError String"
+            ]
+            |> Install.addTypeVariant
         ]
     ]
 
@@ -167,26 +172,29 @@ configAuthTypes =
             |> Install.insertFieldInTypeAlias
         , FieldInTypeAlias.config "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
             |> Install.insertFieldInTypeAlias
-        ]
-    , TypeVariant.makeRule "Types"
-        "FrontendMsg"
-        [ "SignInUser User.SignInData"
-        , "AuthFrontendMsg MagicLink.Types.Msg"
-        , "SetRoute_ Route"
-        , "LiftMsg MagicLink.Types.Msg"
-        ]
-    , TypeVariant.makeRule "Types"
-        "BackendMsg"
-        [ "AuthBackendMsg Auth.Common.BackendMsg"
-        , "AutoLogin SessionId User.SignInData"
-        , "OnConnected SessionId ClientId"
-        ]
-    , TypeVariant.makeRule "Types"
-        "ToBackend"
-        [ "AuthToBackend Auth.Common.ToBackend"
-        , "AddUser String String String"
-        , "RequestSignUp String String String"
-        , "GetUserDictionary"
+        , TypeVariant.config "Types"
+            "FrontendMsg"
+            [ "SignInUser User.SignInData"
+            , "AuthFrontendMsg MagicLink.Types.Msg"
+            , "SetRoute_ Route"
+            , "LiftMsg MagicLink.Types.Msg"
+            ]
+            |> Install.addTypeVariant
+        , TypeVariant.config "Types"
+            "BackendMsg"
+            [ "AuthBackendMsg Auth.Common.BackendMsg"
+            , "AutoLogin SessionId User.SignInData"
+            , "OnConnected SessionId ClientId"
+            ]
+            |> Install.addTypeVariant
+        , TypeVariant.config "Types"
+            "ToBackend"
+            [ "AuthToBackend Auth.Common.ToBackend"
+            , "AddUser String String String"
+            , "RequestSignUp String String String"
+            , "GetUserDictionary"
+            ]
+            |> Install.addTypeVariant
         ]
     ]
 
@@ -222,20 +230,21 @@ configAuthFrontend =
             |> Install.initializer
         , Install.Type.config "Types" "BackendDataStatus" [ "Sunny", "LoadedBackendData", "Spell String Int" ]
             |> Install.addType
-        ]
-    , TypeVariant.makeRule "Types"
-        "ToFrontend"
-        [ "AuthToFrontend Auth.Common.ToFrontend"
-        , "AuthSuccess Auth.Common.UserInfo"
-        , "UserInfoMsg (Maybe Auth.Common.UserInfo)"
-        , "CheckSignInResponse (Result BackendDataStatus User.SignInData)"
-        , "GetLoginTokenRateLimited"
-        , "RegistrationError String"
-        , "SignInError String"
-        , "UserSignedIn (Maybe User.User)"
-        , "UserRegistered User.User"
-        , "GotUserDictionary (Dict.Dict User.EmailString User.User)"
-        , "GotMessage String"
+        , TypeVariant.config "Types"
+            "ToFrontend"
+            [ "AuthToFrontend Auth.Common.ToFrontend"
+            , "AuthSuccess Auth.Common.UserInfo"
+            , "UserInfoMsg (Maybe Auth.Common.UserInfo)"
+            , "CheckSignInResponse (Result BackendDataStatus User.SignInData)"
+            , "GetLoginTokenRateLimited"
+            , "RegistrationError String"
+            , "SignInError String"
+            , "UserSignedIn (Maybe User.User)"
+            , "UserRegistered User.User"
+            , "GotUserDictionary (Dict.Dict User.EmailString User.User)"
+            , "GotMessage String"
+            ]
+            |> Install.addTypeVariant
         ]
     ]
 
@@ -294,10 +303,11 @@ configAuthBackend adminConfig =
 
 configRoute : List Rule
 configRoute =
-    [ -- ROUTE
-      TypeVariant.makeRule "Route" "Route" [ "NotesRoute", "SignInRoute", "AdminRoute" ]
-    , Install.rule "REPLACEME"
-        [ ElementToList.add
+    [ Install.rule "REPLACEME"
+        [ -- ROUTE
+          TypeVariant.config "Route" "Route" [ "NotesRoute", "SignInRoute", "AdminRoute" ]
+            |> Install.addTypeVariant
+        , ElementToList.add
             "Route"
             "routesAndNames"
             [ "(NotesRoute, \"notes\")", "(SignInRoute, \"signin\")", "(AdminRoute, \"admin\")" ]
@@ -317,9 +327,10 @@ addPages pageData =
 
 addPage : ( String, String ) -> List Rule
 addPage ( pageTitle, routeName ) =
-    [ TypeVariant.makeRule "Route" "Route" [ pageTitle ++ "Route" ]
-    , Install.rule "REPLACEME"
-        [ ClauseInCase.config "View.Main" "loadedView" (pageTitle ++ "Route") ("generic model Pages." ++ pageTitle ++ ".view")
+    [ Install.rule "REPLACEME"
+        [ TypeVariant.config "Route" "Route" [ pageTitle ++ "Route" ]
+            |> Install.addTypeVariant
+        , ClauseInCase.config "View.Main" "loadedView" (pageTitle ++ "Route") ("generic model Pages." ++ pageTitle ++ ".view")
             |> Install.insertClauseInCase
         , Import.qualified "View.Main" [ "Pages." ++ pageTitle ]
             |> Install.addImport

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -16,7 +16,7 @@ import Install.ClauseInCase as ClauseInCase
 import Install.ElementToList as ElementToList
 import Install.FieldInTypeAlias as FieldInTypeAlias
 import Install.Function.ReplaceFunction as ReplaceFunction
-import Install.Import as Import exposing (module_, qualified, withAlias, withExposedValues)
+import Install.Import as Import exposing (module_, withAlias, withExposedValues)
 import Install.Initializer as Initializer
 import Install.InitializerCmd as InitializerCmd
 import Install.Subscription as Subscription
@@ -183,6 +183,8 @@ configAuthFrontend =
     [ Install.rule "REPLACEME"
         [ Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ]
             |> Install.addImport
+        , ReplaceFunction.replace "Frontend" "tryLoading" tryLoading2
+            |> Install.replaceFunction
         ]
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , ClauseInCase.config "Frontend" "updateFromBackendLoaded" "AuthToFrontend authToFrontendMsg" "MagicLink.Auth.updateFromBackend authToFrontendMsg model.magicLinkModel |> Tuple.mapFirst (\\magicLinkModel -> { model | magicLinkModel = magicLinkModel })"
@@ -216,8 +218,6 @@ configAuthFrontend =
         ]
     , Install.Type.makeRule "Types" "BackendDataStatus" [ "Sunny", "LoadedBackendData", "Spell String Int" ]
     , ClauseInCase.config "Frontend" "updateLoaded" "LiftMsg _" "( model, Cmd.none )" |> ClauseInCase.makeRule
-    , ReplaceFunction.config "Frontend" "tryLoading" tryLoading2
-        |> ReplaceFunction.makeRule
     ]
 
 
@@ -311,9 +311,11 @@ configView =
     , Install.rule "AddConfig"
         [ Import.qualified "View.Main" [ "MagicLink.Helper", "Pages.Counter", "Pages.SignIn", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes", "User" ]
             |> Install.addImport
+        , ReplaceFunction.replace "View.Main" "headerRow" headerRow
+            |> Install.replaceFunction
+        , ReplaceFunction.replace "View.Main" "makeLinks" makeLinks
+            |> Install.replaceFunction
         ]
-    , ReplaceFunction.config "View.Main" "headerRow" headerRow |> ReplaceFunction.makeRule
-    , ReplaceFunction.config "View.Main" "makeLinks" makeLinks |> ReplaceFunction.makeRule
     ]
 
 

--- a/review/elm.json
+++ b/review/elm.json
@@ -13,6 +13,7 @@
             "jfmengels/elm-review-common": "1.3.3",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.4",
+            "jfmengels/elm-review-simplify": "2.1.5",
             "jfmengels/elm-review-unused": "1.2.3",
             "jxxcarlson/elm-review-codeinstaller": "1.0.0",
             "stil4m/elm-syntax": "7.3.2"
@@ -32,6 +33,7 @@
             "elm-explorations/test": "2.2.0",
             "mdgriffith/style-elements": "5.0.2",
             "miniBill/elm-unicode": "1.1.1",
+            "pzp1997/assoc-list": "1.0.0",
             "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -11,6 +11,7 @@ import NoPrematureLetComputation
 import NoUnused.Dependencies
 import NoUnused.Variables
 import Review.Rule exposing (Rule)
+import Simplify
 
 
 config : List Rule
@@ -24,4 +25,5 @@ config =
     , Docs.ReviewAtDocs.rule
     , NoMissingTypeExpose.rule
     , NoPrematureLetComputation.rule
+    , Simplify.rule Simplify.defaults
     ]

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -6,6 +6,7 @@ import Docs.ReviewLinksAndSections
 import Docs.UpToDateReadmeLinks
 import NoDebug.Log
 import NoDebug.TodoOrToString
+import NoMissingTypeExpose
 import NoPrematureLetComputation
 import NoUnused.Dependencies
 import NoUnused.Variables
@@ -21,5 +22,6 @@ config =
         }
     , Docs.ReviewLinksAndSections.rule
     , Docs.ReviewAtDocs.rule
+    , NoMissingTypeExpose.rule
     , NoPrematureLetComputation.rule
     ]

--- a/src/Install.elm
+++ b/src/Install.elm
@@ -1,4 +1,4 @@
-module Install.Rule exposing
+module Install exposing
     ( rule
     , Installation
     , addImport, addElementToList

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -1,7 +1,7 @@
 module Install.ClauseInCase exposing
     ( Config, config, makeRule
     , withInsertAfter, withInsertAtBeginning
-    , withCustomErrorMessage, CustomError
+    , withCustomErrorMessage
     )
 
 {-| Add a clause to a case expression in a specified function
@@ -36,7 +36,7 @@ Thus we will have
 By default, the clause will be inserted as the last clause. You can change the insertion location using the following functions:
 
 @docs withInsertAfter, withInsertAtBeginning
-@docs withCustomErrorMessage, CustomError
+@docs withCustomErrorMessage
 
 -}
 

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -1,5 +1,5 @@
 module Install.ClauseInCase exposing
-    ( Config, config, makeRule
+    ( Config, config
     , withInsertAfter, withInsertAtBeginning
     , withCustomErrorMessage
     )
@@ -31,7 +31,7 @@ Thus we will have
 
             ...
 
-@docs Config, config, makeRule
+@docs Config, config
 
 By default, the clause will be inserted as the last clause. You can change the insertion location using the following functions:
 
@@ -40,42 +40,13 @@ By default, the clause will be inserted as the last clause. You can change the i
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Expression exposing (Case, Expression(..), FunctionImplementation)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Pattern exposing (Pattern(..))
-import Elm.Syntax.Range exposing (Range)
-import Install.Library
-import List.Extra
-import Maybe.Extra
-import Review.Fix as Fix exposing (Fix)
-import Review.Rule as Rule exposing (Error, Rule)
+import Install.Internal.ClauseInCase as Internal
 
 
 {-| Configuration for rule: add a clause to a case expression in a specified function in a specified module.
 -}
-type Config
-    = Config
-        { moduleName : String
-        , functionName : String
-        , clause : String
-        , functionCall : String
-        , insertAt : InsertAt
-        , customErrorMessage : CustomError
-        }
-
-
-type InsertAt
-    = After String
-    | AtBeginning
-    | AtEnd
-
-
-{-| Custom error message to be displayed when running `elm-review --fix` or `elm-review --fix-all`
--}
-type CustomError
-    = CustomError { message : String, details : List String }
+type alias Config =
+    Internal.Config
 
 
 {-| Basic config to add a new clause to a case expression. If you just need to add a new clause at the end of the case, you can simply use it with the `makeRule` function like this:
@@ -91,244 +62,15 @@ If you need additional configuration, check the `withInsertAfter` and `withCusto
 
 -}
 config : String -> String -> String -> String -> Config
-config moduleName functionName clause functionCall =
-    Config
-        { moduleName = moduleName
+config hostModuleName functionName clause functionCall =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
         , functionName = functionName
         , clause = clause
         , functionCall = functionCall
-        , insertAt = AtEnd
-        , customErrorMessage = CustomError { message = "Add handler for " ++ clause, details = [ "" ] }
+        , insertAt = Internal.AtEnd
+        , customErrorMessage = { message = "Add handler for " ++ clause, details = [ "" ] }
         }
-
-
-{-| Create a rule that adds a clause to a case expression in a specified function. You can use it like this:
-
-    Install.ClauseInCase.config
-        "Backend"
-        "updateFromFrontend"
-        "ResetCounter"
-        "( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )"
-        |> Install.ClauseInCase.makeRule
-
--}
-makeRule : Config -> Rule
-makeRule (Config config_) =
-    let
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor declaration context =
-            declarationVisitor declaration config_.moduleName config_.functionName config_.clause config_.functionCall config_.insertAt context config_.customErrorMessage
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.ClauseInCase" contextCreator
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    }
-
-
-contextCreator : Rule.ContextCreator () { moduleName : ModuleName }
-contextCreator =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-
-            -- ...other fields
-            }
-        )
-        |> Rule.withModuleName
-
-
-declarationVisitor : Node Declaration -> String -> String -> String -> String -> InsertAt -> Context -> CustomError -> ( List (Rule.Error {}), Context )
-declarationVisitor (Node _ declaration) moduleName functionName clause functionCall insertAt context customError =
-    case declaration of
-        FunctionDeclaration function ->
-            let
-                name : String
-                name =
-                    Node.value (Node.value function.declaration).name
-
-                isInCorrectModule =
-                    Install.Library.isInCorrectModule moduleName context
-            in
-            if name == functionName && isInCorrectModule then
-                let
-                    functionDeclaration : FunctionImplementation
-                    functionDeclaration =
-                        Node.value function.declaration
-                in
-                visitFunction clause functionCall functionDeclaration.expression insertAt customError context
-
-            else
-                ( [], context )
-
-        _ ->
-            ( [], context )
-
-
-visitFunction : String -> String -> Node Expression -> InsertAt -> CustomError -> Context -> ( List (Rule.Error {}), Context )
-visitFunction clause functionCall expressionNode insertAt customError context =
-    let
-        couldNotFindCaseError node =
-            Rule.error { message = "Could not find the case expression", details = [ "Try to extract the case to a top-level function and call the rule on the new function" ] } (Node.range node)
-    in
-    case findNestedCaseNode expressionNode of
-        Just caseNode ->
-            let
-                caseExpression =
-                    Node.value caseNode
-
-                ( allCases, patternMatchNode ) =
-                    case caseExpression of
-                        CaseExpression { cases, expression } ->
-                            ( cases, expression )
-
-                        -- impossible case
-                        _ ->
-                            ( [], Node.empty caseExpression )
-
-                getPatterns : List Case -> List Pattern
-                getPatterns cases_ =
-                    cases_
-                        |> List.map (\( pattern, _ ) -> Node.value pattern)
-
-                findClause : String -> List Case -> Bool
-                findClause clause_ cases_ =
-                    List.any
-                        (\pattern -> Install.Library.patternToString (Node.empty pattern) == clause_)
-                        (getPatterns cases_)
-            in
-            if not (findClause clause allCases) then
-                let
-                    isClauseStringPattern =
-                        List.any isStringPattern (getPatterns allCases)
-
-                    rangeToInsert : Maybe ( Range, Int )
-                    rangeToInsert =
-                        rangeToInsertClause insertAt isClauseStringPattern allCases patternMatchNode |> Just
-                in
-                ( [ errorWithFix customError isClauseStringPattern clause functionCall caseNode rangeToInsert ], context )
-
-            else
-                ( [], context )
-
-        Nothing ->
-            ( [ couldNotFindCaseError expressionNode ], context )
-
-
-rangeToInsertClause : InsertAt -> Bool -> List Case -> Node Expression -> ( Range, Int )
-rangeToInsertClause insertAt isClauseStringPattern cases expression =
-    let
-        lastClauseExpression =
-            cases
-                |> List.Extra.last
-                |> Maybe.map Tuple.second
-                |> Maybe.withDefault expression
-
-        lastClauseStartingColumn =
-            cases
-                |> List.Extra.last
-                |> Maybe.map Tuple.first
-                |> Maybe.map (Node.range >> .start >> .column)
-                |> Maybe.withDefault 0
-                |> (\x -> x - 1)
-    in
-    case insertAt of
-        After previousClause ->
-            let
-                normalizedPreviousClause =
-                    if isClauseStringPattern then
-                        escapeString previousClause
-
-                    else
-                        previousClause
-
-                previousClausePattern =
-                    cases
-                        |> List.Extra.find
-                            (\( pattern, _ ) ->
-                                Install.Library.patternToString pattern == normalizedPreviousClause
-                            )
-            in
-            case previousClausePattern of
-                Just pattern ->
-                    pattern
-                        |> Tuple.second
-                        |> Node.range
-                        |> (\range -> ( range, lastClauseStartingColumn ))
-
-                Nothing ->
-                    ( Node.range lastClauseExpression, 0 )
-
-        AtBeginning ->
-            let
-                -- If there are other clauses, the first clause will take the start of other clauses as reference.
-                otherClausesOffset =
-                    cases
-                        |> List.map (\( pattern, _ ) -> Node.range pattern |> .start |> .column)
-                        |> List.minimum
-                        |> Maybe.map (\x -> x - 1)
-
-                -- If there are no other clauses, the first clause will take the case expression as reference. The -2 is to account for the `case` keyword and the space after it
-                firstClauseOffset =
-                    (Node.range expression).start.column - 2
-
-                clauseOffset =
-                    otherClausesOffset
-                        |> Maybe.withDefault firstClauseOffset
-            in
-            ( Node.range expression, clauseOffset )
-
-        AtEnd ->
-            let
-                range =
-                    Node.range lastClauseExpression
-            in
-            ( range, lastClauseStartingColumn )
-
-
-errorWithFix : CustomError -> Bool -> String -> String -> Node a -> Maybe ( Range, Int ) -> Error {}
-errorWithFix (CustomError customError) isClauseStringPattern clause functionCall node errorRange =
-    Rule.errorWithFix
-        customError
-        (Node.range node)
-        (case errorRange of
-            Just ( range, horizontalOffset ) ->
-                let
-                    insertionPoint =
-                        { row = range.end.row + 1, column = 0 }
-
-                    prefix =
-                        String.repeat horizontalOffset " "
-                in
-                [ addMissingCase insertionPoint isClauseStringPattern prefix clause functionCall ]
-
-            Nothing ->
-                []
-        )
-
-
-addMissingCase : { row : Int, column : Int } -> Bool -> String -> String -> String -> Fix
-addMissingCase { row, column } isClauseStringPattern prefix clause functionCall =
-    let
-        clauseToAdd =
-            if isClauseStringPattern then
-                escapeString clause
-
-            else
-                clause
-
-        insertion =
-            "\n" ++ prefix ++ clauseToAdd ++ " -> " ++ functionCall ++ "\n"
-    in
-    Fix.insertAt { row = row, column = column } insertion
-
-
-
--- CONFIGURATION
 
 
 {-| Add a clause after another clause of choice in a case expression. If the clause to insert after is not found, the new clause will be inserted at the end.
@@ -392,10 +134,10 @@ This will add the clause `Aspasia` after the clause `Aristotle` in the `stringTo
 
 -}
 withInsertAfter : String -> Config -> Config
-withInsertAfter clauseToInsertAfter (Config config_) =
-    Config
+withInsertAfter clauseToInsertAfter (Internal.Config config_) =
+    Internal.Config
         { config_
-            | insertAt = After clauseToInsertAfter
+            | insertAt = Internal.After clauseToInsertAfter
         }
 
 
@@ -427,10 +169,10 @@ In this case we will have
 
 -}
 withInsertAtBeginning : Config -> Config
-withInsertAtBeginning (Config config_) =
-    Config
+withInsertAtBeginning (Internal.Config config_) =
+    Internal.Config
         { config_
-            | insertAt = AtBeginning
+            | insertAt = Internal.AtBeginning
         }
 
 
@@ -446,73 +188,12 @@ withInsertAtBeginning (Config config_) =
 
 -}
 withCustomErrorMessage : String -> List String -> Config -> Config
-withCustomErrorMessage errorMessage details (Config config_) =
-    Config
+withCustomErrorMessage errorMessage details (Internal.Config config_) =
+    Internal.Config
         { config_
-            | customErrorMessage = CustomError { message = errorMessage, details = details }
+            | customErrorMessage = { message = errorMessage, details = details }
         }
 
 
 
 -- HELPERS
-
-
-findNestedCaseNode : Node Expression -> Maybe (Node Expression)
-findNestedCaseNode node =
-    case Node.value node of
-        CaseExpression _ ->
-            Just node
-
-        Application nodes ->
-            List.Extra.findMap findNestedCaseNode nodes
-
-        OperatorApplication _ _ first second ->
-            Maybe.Extra.orLazy (findNestedCaseNode first) (\_ -> findNestedCaseNode second)
-
-        IfBlock _ thenNode elseNode ->
-            Maybe.Extra.orLazy (findNestedCaseNode thenNode) (\_ -> findNestedCaseNode elseNode)
-
-        Negation nestedNode ->
-            findNestedCaseNode nestedNode
-
-        TupledExpression nodes ->
-            List.Extra.findMap findNestedCaseNode nodes
-
-        ParenthesizedExpression nestedNode ->
-            findNestedCaseNode nestedNode
-
-        LetExpression { expression } ->
-            findNestedCaseNode expression
-
-        LambdaExpression { expression } ->
-            findNestedCaseNode expression
-
-        ListExpr nodes ->
-            List.Extra.findMap findNestedCaseNode nodes
-
-        _ ->
-            Nothing
-
-
-isStringPattern : Pattern -> Bool
-isStringPattern pattern =
-    case pattern of
-        StringPattern _ ->
-            True
-
-        _ ->
-            False
-
-
-escapeString : String -> String
-escapeString str =
-    if isStringScaped str then
-        str
-
-    else
-        "\"" ++ str ++ "\""
-
-
-isStringScaped : String -> Bool
-isStringScaped str =
-    String.startsWith "\\" str

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -268,7 +268,7 @@ rangeToInsertClause insertAt isClauseStringPattern cases expression =
                 -- If there are other clauses, the first clause will take the start of other clauses as reference.
                 otherClausesOffset =
                     cases
-                        |> List.map (\( pattern, _ ) -> Node.range pattern |> .start >> .column)
+                        |> List.map (\( pattern, _ ) -> Node.range pattern |> .start |> .column)
                         |> List.minimum
                         |> Maybe.map (\x -> x - 1)
 

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -206,7 +206,7 @@ visitFunction clause functionCall expressionNode insertAt customError context =
                     isClauseStringPattern =
                         List.any isStringPattern (getPatterns allCases)
 
-                    rangeToInsert : Maybe ( Range, Int, Int )
+                    rangeToInsert : Maybe ( Range, Int )
                     rangeToInsert =
                         rangeToInsertClause insertAt isClauseStringPattern allCases patternMatchNode |> Just
                 in
@@ -219,7 +219,7 @@ visitFunction clause functionCall expressionNode insertAt customError context =
             ( [ couldNotFindCaseError expressionNode ], context )
 
 
-rangeToInsertClause : InsertAt -> Bool -> List Case -> Node Expression -> ( Range, Int, Int )
+rangeToInsertClause : InsertAt -> Bool -> List Case -> Node Expression -> ( Range, Int )
 rangeToInsertClause insertAt isClauseStringPattern cases expression =
     let
         lastClauseExpression =
@@ -258,10 +258,10 @@ rangeToInsertClause insertAt isClauseStringPattern cases expression =
                     pattern
                         |> Tuple.second
                         |> Node.range
-                        |> (\range -> ( range, 1, lastClauseStartingColumn ))
+                        |> (\range -> ( range, lastClauseStartingColumn ))
 
                 Nothing ->
-                    ( Node.range lastClauseExpression, 1, 0 )
+                    ( Node.range lastClauseExpression, 0 )
 
         AtBeginning ->
             let
@@ -280,26 +280,26 @@ rangeToInsertClause insertAt isClauseStringPattern cases expression =
                     otherClausesOffset
                         |> Maybe.withDefault firstClauseOffset
             in
-            ( Node.range expression, 1, clauseOffset )
+            ( Node.range expression, clauseOffset )
 
         AtEnd ->
             let
                 range =
                     Node.range lastClauseExpression
             in
-            ( range, 1, lastClauseStartingColumn )
+            ( range, lastClauseStartingColumn )
 
 
-errorWithFix : CustomError -> Bool -> String -> String -> Node a -> Maybe ( Range, Int, Int ) -> Error {}
+errorWithFix : CustomError -> Bool -> String -> String -> Node a -> Maybe ( Range, Int ) -> Error {}
 errorWithFix (CustomError customError) isClauseStringPattern clause functionCall node errorRange =
     Rule.errorWithFix
         customError
         (Node.range node)
         (case errorRange of
-            Just ( range, verticalOffset, horizontalOffset ) ->
+            Just ( range, horizontalOffset ) ->
                 let
                     insertionPoint =
-                        { row = range.end.row + verticalOffset, column = 0 }
+                        { row = range.end.row + 1, column = 0 }
 
                     prefix =
                         String.repeat horizontalOffset " "

--- a/src/Install/ElementToList.elm
+++ b/src/Install/ElementToList.elm
@@ -1,145 +1,41 @@
-module Install.ElementToList exposing (makeRule)
+module Install.ElementToList exposing (add, Config)
 
 {-|
 
-@docs makeRule
+@docs add, Config
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Expression exposing (Expression(..))
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range exposing (Location)
-import Install.Library
-import Review.Fix as Fix
-import Review.Rule as Rule exposing (Rule)
-import String.Extra
+import Install.Internal.ElementToList as Internal
+
+
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
 
 
 {-| Create a rule that adds elements to a list.
 
 For example, the rule
 
-    Install.ElementToList.makeRule
-        "User"
-        "userTypes"
-        [ "Admin", "SystemAdmin" ]
+    Install.Rule.rule
+        [ Install.ElementToList.add
+            "User"
+            "userTypes"
+            [ "Admin", "SystemAdmin" ]
+            |> Install.Rule.addElementToList
+        ]
 
 results in the following fix for function `User.userTypes`:
 
     [ Standard ] -> [ Standard, Admin, SystemAdmin ]
 
 -}
-makeRule : String -> String -> List String -> Rule
-makeRule moduleName functionName elements =
-    let
-        visitor =
-            declarationVisitor moduleName functionName elements
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.ElementToList" initialContext
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    }
-
-
-initialContext : Rule.ContextCreator () Context
-initialContext =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-            }
-        )
-        |> Rule.withModuleName
-
-
-declarationVisitor : String -> String -> List String -> Node Declaration -> Context -> ( List (Rule.Error {}), Context )
-declarationVisitor moduleName functionName items (Node _ declaration) context =
-    if Install.Library.isInCorrectModule moduleName context then
-        case declaration of
-            FunctionDeclaration function ->
-                if Install.Library.isInCorrectFunction functionName function then
-                    let
-                        implementation =
-                            Node.value function.declaration
-
-                        expr =
-                            implementation.expression
-
-                        data =
-                            case Node.value expr of
-                                ListExpr nodes ->
-                                    Just nodes
-
-                                _ ->
-                                    Nothing
-                    in
-                    case data of
-                        Nothing ->
-                            ( [], context )
-
-                        Just listElements ->
-                            let
-                                isAlreadyImplemented =
-                                    Install.Library.areItemsInList items listElements
-                            in
-                            if isAlreadyImplemented then
-                                ( [], context )
-
-                            else
-                                let
-                                    replacementCode =
-                                        items
-                                            |> List.map (\item -> ", " ++ item)
-                                            |> String.concat
-
-                                    lastElementLocation =
-                                        listElements
-                                            |> List.reverse
-                                            |> List.head
-                                            |> Maybe.map (Node.range >> .end)
-                                            |> Maybe.withDefault (Node.range expr).start
-                                in
-                                ( [ errorWithFix replacementCode expr lastElementLocation ], context )
-
-                else
-                    ( [], context )
-
-            _ ->
-                ( [], context )
-
-    else
-        ( [], context )
-
-
-errorWithFix : String -> Node Expression -> Location -> Rule.Error {}
-errorWithFix replacementCode expression lastElementLocation =
-    let
-        numberOfElementsAdded =
-            String.Extra.countOccurrences ", " replacementCode
-
-        replacementText =
-            if numberOfElementsAdded == 1 then
-                "1 element"
-
-            else
-                String.fromInt numberOfElementsAdded ++ " elements"
-    in
-    Rule.errorWithFix
-        { message = "Add " ++ replacementText ++ " to the list"
-        , details =
-            [ ""
-            ]
+add : String -> String -> List String -> Config
+add hostModuleName functionName elements =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , functionName = functionName
+        , elements = elements
         }
-        (Node.range expression)
-        [ Fix.insertAt
-            { row = lastElementLocation.row
-            , column = lastElementLocation.column
-            }
-            (String.Extra.clean replacementCode)
-        ]

--- a/src/Install/ElementToList.elm
+++ b/src/Install/ElementToList.elm
@@ -38,7 +38,7 @@ makeRule moduleName functionName elements =
             declarationVisitor moduleName functionName elements
     in
     Rule.newModuleRuleSchemaUsingContextCreator "Install.ElementToList" initialContext
-        |> Rule.withDeclarationExitVisitor visitor
+        |> Rule.withDeclarationEnterVisitor visitor
         |> Rule.providesFixesForModuleRule
         |> Rule.fromModuleRuleSchema
 

--- a/src/Install/FieldInTypeAlias.elm
+++ b/src/Install/FieldInTypeAlias.elm
@@ -1,4 +1,4 @@
-module Install.FieldInTypeAlias exposing (makeRule)
+module Install.FieldInTypeAlias exposing (Config, config)
 
 {-| Add a field to specified type alias
 in a specified module. For example, if you put the code below in your
@@ -17,20 +17,18 @@ Thus we will have
         , quot : String
         }
 
-@docs makeRule
+@docs Config, config
 
 -}
 
-import Elm.Syntax.Declaration as Declaration exposing (Declaration)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node)
-import Elm.Syntax.Range exposing (Range)
-import Elm.Syntax.TypeAnnotation as TypeAnnotation
-import Install.Library
-import Review.Fix as Fix exposing (Fix)
-import Review.Rule as Rule exposing (Error, Rule)
-import Set exposing (Set)
-import Set.Extra
+import Install.Internal.FieldInTypeAlias as Internal
+import Set
+
+
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
 
 
 {-| Create a rule that adds a field to a type alias in a specified module. Example usage:
@@ -56,148 +54,13 @@ we will have
         }
 
 -}
-makeRule : String -> String -> List String -> Rule
-makeRule moduleName_ typeName_ fieldsDefinition_ =
-    let
-        fieldsName =
-            List.map getFieldName fieldsDefinition_
+config : String -> String -> List String -> Config
+config hostModuleName typeName fieldDefinitions =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , typeName = typeName
+        , fieldDefinitions = fieldDefinitions
+        , fieldNames =
+            List.map Internal.getFieldName fieldDefinitions
                 |> Set.fromList
-
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor =
-            declarationVisitor moduleName_ typeName_ fieldsName fieldsDefinition_
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.FieldInTypeAlias" contextCreator
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    }
-
-
-contextCreator : Rule.ContextCreator () { moduleName : ModuleName }
-contextCreator =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-
-            -- ...other fields
-            }
-        )
-        |> Rule.withModuleName
-
-
-errorWithFix : String -> Set String -> String -> Node a -> Maybe Range -> Error {}
-errorWithFix typeName_ fieldsName fieldCode node errorRange =
-    let
-        fieldsNameList =
-            Set.toList fieldsName
-
-        fieldName =
-            case fieldsNameList of
-                [ field ] ->
-                    field
-
-                _ ->
-                    "fields " ++ String.join ", " fieldsNameList
-    in
-    Rule.errorWithFix
-        { message = "Add " ++ fieldName ++ " to " ++ typeName_
-        , details =
-            [ "" ]
         }
-        (Node.range node)
-        (case errorRange of
-            Just range ->
-                [ fixMissingField range.end fieldCode ]
-
-            Nothing ->
-                []
-        )
-
-
-fixMissingField : { row : Int, column : Int } -> String -> Fix
-fixMissingField { row, column } fieldCode =
-    let
-        range =
-            { start = { row = row, column = 0 }, end = { row = row, column = column } }
-    in
-    Fix.replaceRangeBy range fieldCode
-
-
-declarationVisitor : String -> String -> Set String -> List String -> Node Declaration -> Context -> ( List (Error {}), Context )
-declarationVisitor moduleName_ typeName_ fieldsName_ fieldsDefinition_ node context =
-    case Node.value node of
-        Declaration.AliasDeclaration type_ ->
-            let
-                isInCorrectModule =
-                    Install.Library.isInCorrectModule moduleName_ context
-
-                fieldsOfNode : Node Declaration -> List String
-                fieldsOfNode node_ =
-                    case Node.value node_ of
-                        Declaration.AliasDeclaration typeAlias ->
-                            case typeAlias.typeAnnotation |> Node.value of
-                                TypeAnnotation.Record fields ->
-                                    fields
-                                        |> List.map (Node.value >> Tuple.first >> Node.value)
-
-                                _ ->
-                                    []
-
-                        _ ->
-                            []
-
-                shouldFix : Node Declaration -> Bool
-                shouldFix node_ =
-                    let
-                        fieldsOfNode_ =
-                            fieldsOfNode node_
-                    in
-                    not <| Set.Extra.isSubsetOf (Set.fromList fieldsOfNode_) fieldsName_
-            in
-            if isInCorrectModule && Node.value type_.name == typeName_ && shouldFix node then
-                let
-                    fieldsToAdd : Set String
-                    fieldsToAdd =
-                        Set.diff fieldsName_ (Set.fromList <| fieldsOfNode node)
-
-                    getFieldCode field =
-                        "    , " ++ field ++ "\n"
-
-                    closeRecord =
-                        "    }"
-
-                    -- filter out the fields that are already in the type alias
-                    newFields : List String
-                    newFields =
-                        fieldsDefinition_
-                            |> List.filter (\field -> Set.member (getFieldName field) fieldsToAdd)
-
-                    fieldsCode =
-                        newFields
-                            |> List.map getFieldCode
-                            |> String.concat
-                            |> (\fields -> fields ++ closeRecord)
-                in
-                ( [ errorWithFix typeName_ fieldsToAdd fieldsCode node (Just <| Node.range node) ]
-                , context
-                )
-
-            else
-                ( [], context )
-
-        _ ->
-            ( [], context )
-
-
-getFieldName : String -> String
-getFieldName field =
-    field
-        |> String.split ":"
-        |> List.head
-        |> Maybe.withDefault ""
-        |> String.trim

--- a/src/Install/Function/InsertFunction.elm
+++ b/src/Install/Function/InsertFunction.elm
@@ -1,4 +1,4 @@
-module Install.Function.InsertFunction exposing (makeRule, config, Config, CustomError, withInsertAfter)
+module Install.Function.InsertFunction exposing (makeRule, config, Config, withInsertAfter)
 
 {-| Add a function in a given module if it is not present.
 
@@ -22,7 +22,7 @@ The form of the rule is the same for nested modules:
             "hoho model = { model | interest = 1.03 * model.interest }"
             |> Install.Function.InsertFunction.makeRule
 
-@docs makeRule, config, Config, CustomError, withInsertAfter
+@docs makeRule, config, Config, withInsertAfter
 
 -}
 

--- a/src/Install/Function/InsertFunction.elm
+++ b/src/Install/Function/InsertFunction.elm
@@ -45,15 +45,8 @@ type Config
         , functionName : String
         , functionImplementation : String
         , theFunctionNodeExpression : Maybe (Node Expression)
-        , customErrorMessage : CustomError
         , insertAt : InsertAt
         }
-
-
-{-| Custom error message to be displayed when running `elm-review --fix` or `elm-review --fix-all`
--}
-type CustomError
-    = CustomError { message : String, details : List String }
 
 
 type InsertAt
@@ -77,7 +70,6 @@ config moduleName functionName functionImplementation =
         , functionName = functionName
         , functionImplementation = functionImplementation
         , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = String.split "." moduleName } functionImplementation
-        , customErrorMessage = CustomError { message = "Add function \"" ++ functionName ++ "\".", details = [ "" ] }
         , insertAt = AtEnd
         }
 

--- a/src/Install/Function/InsertFunction.elm
+++ b/src/Install/Function/InsertFunction.elm
@@ -1,148 +1,60 @@
-module Install.Function.InsertFunction exposing (makeRule, config, Config, withInsertAfter)
+module Install.Function.InsertFunction exposing
+    ( insert
+    , Config, withInsertAfter
+    )
 
 {-| Add a function in a given module if it is not present.
 
     -- code for ReviewConfig.elm:
     rule =
-        Install.Function.InsertFunction.config
+        Install.Function.InsertFunction.insert
             "Frontend"
             "view"
             """view model =
             Html.text "This is a test\""""
-            |> Install.Function.InsertFunction.makeRule
+            |> Install.insertFunction
 
 Running this rule will insert the function `view` in the module `Frontend` with the provided implementation.
 
 The form of the rule is the same for nested modules:
 
     rule =
-        Install.Function.InsertFunction.config
+        Install.Function.InsertFunction.insert
             "Foo.Bar"
             "earnInterest"
             "hoho model = { model | interest = 1.03 * model.interest }"
-            |> Install.Function.InsertFunction.makeRule
+            |> Install.insertFunction
 
-@docs makeRule, config, Config, withInsertAfter
+@docs insert
+@docs Config, withInsertAfter
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration)
-import Elm.Syntax.Expression exposing (Expression)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node)
-import Elm.Syntax.Range as Range exposing (Range)
+import Install.Internal.InsertFunction as Internal
 import Install.Library
-import Review.Fix as Fix
-import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
-import Review.Rule as Rule exposing (Error, Rule)
 
 
 {-| Configuration for rule: add a function in a specified module if it does not already exist.
 -}
-type Config
-    = Config
-        { moduleName : String
-        , functionName : String
-        , functionImplementation : String
-        , theFunctionNodeExpression : Maybe (Node Expression)
-        , insertAt : InsertAt
+type alias Config =
+    Internal.Config
+
+
+{-| Initialize the configuration for the rule.
+-}
+insert : String -> String -> String -> Config
+insert hostModuleName functionName functionImplementation =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , functionName = functionName
+        , functionImplementation = functionImplementation
+        , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = String.split "." hostModuleName } functionImplementation
+        , insertAt = Internal.AtEnd
         }
-
-
-type InsertAt
-    = After String
-    | AtEnd
 
 
 {-| Add the function after a specified declaration. Just give the name of a function, type, type alias or port and the function will be added after that declaration. Only work if the function is being added and not replaced.
 -}
 withInsertAfter : String -> Config -> Config
-withInsertAfter previousDeclaration (Config config_) =
-    Config { config_ | insertAt = After previousDeclaration }
-
-
-{-| Initialize the configuration for the rule.
--}
-config : String -> String -> String -> Config
-config moduleName functionName functionImplementation =
-    Config
-        { moduleName = moduleName
-        , functionName = functionName
-        , functionImplementation = functionImplementation
-        , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = String.split "." moduleName } functionImplementation
-        , insertAt = AtEnd
-        }
-
-
-{-| Create a rule that adds a function in a given module if it is not present.
--}
-makeRule : Config -> Rule
-makeRule config_ =
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.Function.InsertFunction" initialContext
-        |> Rule.withDeclarationEnterVisitor (\node context -> ( [], declarationVisitor config_ node context ))
-        |> Rule.withFinalModuleEvaluation (finalEvaluation config_)
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    , lookupTable : ModuleNameLookupTable
-    , lastDeclarationRange : Range
-    , appliedFix : Bool
-    }
-
-
-initialContext : Rule.ContextCreator () Context
-initialContext =
-    Rule.initContextCreator
-        (\lookupTable moduleName () -> { lookupTable = lookupTable, moduleName = moduleName, lastDeclarationRange = Range.empty, appliedFix = False })
-        |> Rule.withModuleNameLookupTable
-        |> Rule.withModuleName
-
-
-declarationVisitor : Config -> Node Declaration -> Context -> Context
-declarationVisitor (Config config_) declaration context =
-    let
-        declarationName =
-            Install.Library.getDeclarationName declaration
-    in
-    if declarationName == config_.functionName then
-        { context | appliedFix = True }
-
-    else
-        case config_.insertAt of
-            After previousDeclaration ->
-                if Install.Library.getDeclarationName declaration == previousDeclaration then
-                    { context | lastDeclarationRange = Node.range declaration }
-
-                else
-                    context
-
-            AtEnd ->
-                { context | lastDeclarationRange = Node.range declaration }
-
-
-finalEvaluation : Config -> Context -> List (Rule.Error {})
-finalEvaluation (Config config_) context =
-    if not context.appliedFix && Install.Library.isInCorrectModule config_.moduleName context then
-        addFunction { range = context.lastDeclarationRange, functionName = config_.functionName, functionImplementation = config_.functionImplementation }
-
-    else
-        []
-
-
-type alias FixConfig =
-    { range : Range
-    , functionName : String
-    , functionImplementation : String
-    }
-
-
-addFunction : FixConfig -> List (Error {})
-addFunction fixConfig =
-    [ Rule.errorWithFix
-        { message = "Add function \"" ++ fixConfig.functionName ++ "\"", details = [ "" ] }
-        fixConfig.range
-        [ Fix.insertAt { row = fixConfig.range.end.row + 1, column = 0 } fixConfig.functionImplementation ]
-    ]
+withInsertAfter previousDeclaration (Internal.Config config_) =
+    Internal.Config { config_ | insertAt = Internal.After previousDeclaration }

--- a/src/Install/Function/InsertFunction.elm
+++ b/src/Install/Function/InsertFunction.elm
@@ -31,7 +31,6 @@ The form of the rule is the same for nested modules:
 -}
 
 import Install.Internal.InsertFunction as Internal
-import Install.Library
 
 
 {-| Configuration for rule: add a function in a specified module if it does not already exist.
@@ -48,7 +47,6 @@ insert hostModuleName functionName functionImplementation =
         { hostModuleName = String.split "." hostModuleName
         , functionName = functionName
         , functionImplementation = functionImplementation
-        , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = String.split "." hostModuleName } functionImplementation
         , insertAt = Internal.AtEnd
         }
 

--- a/src/Install/Function/ReplaceFunction.elm
+++ b/src/Install/Function/ReplaceFunction.elm
@@ -1,4 +1,4 @@
-module Install.Function.ReplaceFunction exposing (makeRule, config, Config, CustomError)
+module Install.Function.ReplaceFunction exposing (makeRule, config, Config)
 
 {-| Replace a function in a given module with a new implementation.
 
@@ -22,7 +22,7 @@ The form of the rule is the same for nested modules:
             "hoho model = { model | interest = 1.03 * model.interest }"
             |> Install.Function.ReplaceFunction.makeRule
 
-@docs makeRule, config, Config, CustomError
+@docs makeRule, config, Config
 
 -}
 

--- a/src/Install/Function/ReplaceFunction.elm
+++ b/src/Install/Function/ReplaceFunction.elm
@@ -45,14 +45,7 @@ type Config
         , functionName : String
         , functionImplementation : String
         , theFunctionNodeExpression : Maybe (Node Expression)
-        , customErrorMessage : CustomError
         }
-
-
-{-| Custom error message to be displayed when running `elm-review --fix` or `elm-review --fix-all`
--}
-type CustomError
-    = CustomError { message : String, details : List String }
 
 
 {-| Initialize the configuration for the rule.
@@ -64,7 +57,6 @@ config moduleName functionName functionImplementation =
         , functionName = functionName
         , functionImplementation = functionImplementation
         , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = String.split "." moduleName } functionImplementation
-        , customErrorMessage = CustomError { message = "Replace function \"" ++ functionName ++ "\" with new code.", details = [ "" ] }
         }
 
 

--- a/src/Install/Function/ReplaceFunction.elm
+++ b/src/Install/Function/ReplaceFunction.elm
@@ -1,4 +1,4 @@
-module Install.Function.ReplaceFunction exposing (makeRule, config, Config)
+module Install.Function.ReplaceFunction exposing (Config, replace)
 
 {-| Replace a function in a given module with a new implementation.
 
@@ -22,115 +22,25 @@ The form of the rule is the same for nested modules:
             "hoho model = { model | interest = 1.03 * model.interest }"
             |> Install.Function.ReplaceFunction.makeRule
 
-@docs makeRule, config, Config
+@docs Config, replace
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Expression exposing (Expression, Function)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node)
-import Elm.Syntax.Range exposing (Range)
-import Install.Library
-import Review.Fix as Fix
-import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
-import Review.Rule as Rule exposing (Error, Rule)
+import Install.Internal.ReplaceFunction as Internal
 
 
 {-| Configuration for rule: replace a function in a specified module with a new implementation.
 -}
-type Config
-    = Config
-        { moduleName : String
-        , functionName : String
-        , functionImplementation : String
-        , theFunctionNodeExpression : Maybe (Node Expression)
-        }
+type alias Config =
+    Internal.Config
 
 
 {-| Initialize the configuration for the rule.
 -}
-config : String -> String -> String -> Config
-config moduleName functionName functionImplementation =
-    Config
-        { moduleName = moduleName
+replace : String -> String -> String -> Config
+replace hostModuleName functionName functionImplementation =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
         , functionName = functionName
         , functionImplementation = functionImplementation
-        , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = String.split "." moduleName } functionImplementation
         }
-
-
-{-| Create a rule that replaces a function in a given module with a new implementation.
--}
-makeRule : Config -> Rule
-makeRule config_ =
-    let
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor declaration context =
-            declarationVisitor context config_ declaration
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.Function.ReplaceFunction" initialContext
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    , lookupTable : ModuleNameLookupTable
-    }
-
-
-initialContext : Rule.ContextCreator () Context
-initialContext =
-    Rule.initContextCreator
-        (\lookupTable moduleName () -> { lookupTable = lookupTable, moduleName = moduleName })
-        |> Rule.withModuleNameLookupTable
-        |> Rule.withModuleName
-
-
-declarationVisitor : Context -> Config -> Node Declaration -> ( List (Rule.Error {}), Context )
-declarationVisitor context (Config config_) declaration =
-    case Node.value declaration of
-        FunctionDeclaration function ->
-            let
-                name : String
-                name =
-                    Install.Library.getDeclarationName declaration
-
-                isInCorrectModule =
-                    Install.Library.isInCorrectModule config_.moduleName context
-
-                isInCorrectFunction =
-                    isInCorrectModule && name == config_.functionName
-
-                isNotImplemented : Function -> { a | functionImplementation : String } -> Bool
-                isNotImplemented f confg =
-                    isInCorrectFunction && (Install.Library.isStringEqualToDeclaration confg.functionImplementation declaration |> not)
-            in
-            if isNotImplemented function config_ then
-                replaceFunction { range = Node.range declaration, functionName = config_.functionName, functionImplementation = config_.functionImplementation } context
-
-            else
-                ( [], context )
-
-        _ ->
-            ( [], context )
-
-
-replaceFunction : FixConfig -> Context -> ( List (Error {}), Context )
-replaceFunction fixConfig context =
-    ( [ Rule.errorWithFix
-            { message = "Replace function \"" ++ fixConfig.functionName ++ "\"", details = [ "" ] }
-            fixConfig.range
-            [ Fix.replaceRangeBy fixConfig.range fixConfig.functionImplementation ]
-      ]
-    , context
-    )
-
-
-type alias FixConfig =
-    { range : Range
-    , functionName : String
-    , functionImplementation : String
-    }

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -147,27 +147,29 @@ initialContext =
 
 importVisitor : Config -> Node Import -> Context -> ( List (Error {}), Context )
 importVisitor (Config config_) node context =
-    case Node.value node |> .moduleName |> Node.value of
-        currentModuleName ->
-            if config_.hostModuleName == context.moduleName then
-                let
-                    allModuleNames =
-                        List.map .moduleToImport config_.imports
+    if config_.hostModuleName == context.moduleName then
+        let
+            currentModuleName : ModuleName
+            currentModuleName =
+                Node.value node |> .moduleName |> Node.value
 
-                    foundImports =
-                        currentModuleName :: context.foundImports
+            allModuleNames =
+                List.map .moduleToImport config_.imports
 
-                    areAllImportsFound =
-                        List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
-                in
-                if areAllImportsFound then
-                    ( [], { context | moduleWasImported = True, lastNodeRange = Node.range node } )
+            foundImports =
+                currentModuleName :: context.foundImports
 
-                else
-                    ( [], { context | lastNodeRange = Node.range node, foundImports = foundImports } )
+            areAllImportsFound =
+                List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
+        in
+        if areAllImportsFound then
+            ( [], { context | moduleWasImported = True, lastNodeRange = Node.range node } )
 
-            else
-                ( [], context )
+        else
+            ( [], { context | lastNodeRange = Node.range node, foundImports = foundImports } )
+
+    else
+        ( [], context )
 
 
 moduleDefinitionVisitor : Node Module -> Context -> ( List (Error {}), Context )

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -154,7 +154,7 @@ importVisitor (Config config_) node context =
                     List.map .moduleToImport config_.imports
 
                 foundImports =
-                    context.foundImports ++ [ currentModuleName ]
+                    currentModuleName :: context.foundImports
 
                 areAllImportsFound =
                     List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -1,4 +1,7 @@
-module Install.Import exposing (config, ImportData, module_, withAlias, withExposedValues, qualified, makeRule)
+module Install.Import exposing
+    ( config, Config
+    , ImportData, module_, withAlias, withExposedValues, qualified, makeRule
+    )
 
 {-| Add import statements to a given module.
 For example, to add `import Foo.Bar` to the `Frontend` module, you can use the following configuration:
@@ -24,7 +27,8 @@ There is a shortcut for importing modules with no alias or exposed values
         ]
         |> Install.Import.makeRule
 
-@docs config, ImportData, module_, withAlias, withExposedValues, qualified, makeRule
+@docs config, Config
+@docs ImportData, module_, withAlias, withExposedValues, qualified, makeRule
 
 -}
 

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -43,7 +43,6 @@ type Config
     = Config
         { hostModuleName : List String
         , imports : List ImportedModule
-        , customErrorMessage : CustomError
         }
 
 
@@ -54,12 +53,6 @@ type alias ImportedModule =
     }
 
 
-{-| Custom error message to be displayed when running `elm-review --fix` or `elm-review --fix-all`
--}
-type CustomError
-    = CustomError { message : String, details : List String }
-
-
 {-| Initialize the configuration for the rule.
 -}
 config : String -> List { moduleToImport : String, alias : Maybe String, exposedValues : Maybe (List String) } -> Config
@@ -67,7 +60,6 @@ config hostModuleName_ imports =
     Config
         { hostModuleName = String.split "." hostModuleName_
         , imports = List.map (\{ moduleToImport, alias, exposedValues } -> { moduleToImport = String.split "." moduleToImport, alias = alias, exposedValues = exposedValues }) imports
-        , customErrorMessage = CustomError { message = "Install imports in module " ++ hostModuleName_, details = [ "" ] }
         }
 
 
@@ -113,7 +105,6 @@ qualified hostModuleName_ imports =
     Config
         { hostModuleName = String.split "." hostModuleName_
         , imports = List.map (\moduleToImport -> { moduleToImport = String.split "." moduleToImport, alias = Nothing, exposedValues = Nothing }) imports
-        , customErrorMessage = CustomError { message = "Install imports in module " ++ hostModuleName_, details = [ "" ] }
         }
 
 

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -149,21 +149,25 @@ importVisitor : Config -> Node Import -> Context -> ( List (Error {}), Context )
 importVisitor (Config config_) node context =
     case Node.value node |> .moduleName |> Node.value of
         currentModuleName ->
-            let
-                allModuleNames =
-                    List.map .moduleToImport config_.imports
+            if config_.hostModuleName == context.moduleName then
+                let
+                    allModuleNames =
+                        List.map .moduleToImport config_.imports
 
-                foundImports =
-                    currentModuleName :: context.foundImports
+                    foundImports =
+                        currentModuleName :: context.foundImports
 
-                areAllImportsFound =
-                    List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
-            in
-            if areAllImportsFound && config_.hostModuleName == context.moduleName then
-                ( [], { context | moduleWasImported = True, lastNodeRange = Node.range node } )
+                    areAllImportsFound =
+                        List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
+                in
+                if areAllImportsFound then
+                    ( [], { context | moduleWasImported = True, lastNodeRange = Node.range node } )
+
+                else
+                    ( [], { context | lastNodeRange = Node.range node, foundImports = foundImports } )
 
             else
-                ( [], { context | lastNodeRange = Node.range node, foundImports = foundImports } )
+                ( [], context )
 
 
 moduleDefinitionVisitor : Node Module -> Context -> ( List (Error {}), Context )

--- a/src/Install/Initializer.elm
+++ b/src/Install/Initializer.elm
@@ -1,4 +1,4 @@
-module Install.Initializer exposing (makeRule)
+module Install.Initializer exposing (config, Config)
 
 {-| Add field = value pairs to the body of a function like `init` in which the
 the return value is of the form `( SomeTypeAlias, Cmd msg )`. As in
@@ -21,25 +21,17 @@ Thus we will have
          , Cmd.none
          )
 
-@docs makeRule
+@docs config, Config
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Expression exposing (Expression(..), Function, FunctionImplementation)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range exposing (Range)
-import Install.Library
-import List.Extra
-import Review.Fix as Fix exposing (Fix)
-import Review.Rule as Rule exposing (Error, Rule)
-import Set exposing (Set)
-import Set.Extra
+import Install.Internal.Initializer as Internal
 
 
-type alias Ignored =
-    Set String
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
 
 
 {-| Create a rule that adds fields to the body of a function like
@@ -53,157 +45,10 @@ field name and value to be added to the function:
         [ { field = "message", value = "\"hohoho!\"" }, { field = "counter", value = "0" } ]
 
 -}
-makeRule : String -> String -> List { field : String, value : String } -> Rule
-makeRule moduleName functionName data =
-    let
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor =
-            declarationVisitor moduleName functionName data
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.Initializer" contextCreator
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    }
-
-
-contextCreator : Rule.ContextCreator () { moduleName : ModuleName }
-contextCreator =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-
-            -- ...other fields
-            }
-        )
-        |> Rule.withModuleName
-
-
-declarationVisitor : String -> String -> List { field : String, value : String } -> Node Declaration -> Context -> ( List (Rule.Error {}), Context )
-declarationVisitor moduleName functionName data (Node _ declaration) context =
-    case declaration of
-        FunctionDeclaration function ->
-            let
-                name : String
-                name =
-                    Node.value (Node.value function.declaration).name
-
-                isInCorrectModule =
-                    Install.Library.isInCorrectModule moduleName context
-            in
-            if name == functionName && isInCorrectModule then
-                visitFunction data Set.empty function context
-
-            else
-                ( [], context )
-
-        _ ->
-            ( [], context )
-
-
-visitFunction : List { field : String, value : String } -> Ignored -> Function -> Context -> ( List (Rule.Error {}), Context )
-visitFunction data ignored function context =
-    let
-        declaration : FunctionImplementation
-        declaration =
-            Node.value function.declaration
-
-        ( fieldNames, lastRange ) =
-            getFieldNamesAndLastRange (Node.value declaration.expression)
-
-        existingFields =
-            Set.fromList fieldNames
-
-        newFields =
-            List.map .field data |> Set.fromList
-    in
-    if not <| Set.Extra.isSubsetOf existingFields newFields then
-        ( [ errorWithFix data function.declaration (Just lastRange) ], context )
-
-    else
-        ( [], context )
-
-
-errorWithFix : List { field : String, value : String } -> Node a -> Maybe Range -> Error {}
-errorWithFix data node errorRange =
-    Rule.errorWithFix
-        { message = "Add fields to the model"
-        , details =
-            [ ""
-            ]
+config : String -> String -> List { field : String, value : String } -> Config
+config hostModuleName functionName data =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , functionName = functionName
+        , data = data
         }
-        (Node.range node)
-        (case errorRange of
-            Just range ->
-                let
-                    insertionPoint =
-                        { row = range.end.row, column = range.end.column }
-                in
-                [ addMissingCases insertionPoint data ]
-
-            Nothing ->
-                []
-        )
-
-
-addMissingCases : { row : Int, column : Int } -> List { field : String, value : String } -> Fix
-addMissingCases insertionPoint data =
-    let
-        insertion =
-            ", " ++ (List.map (\{ field, value } -> field ++ " = " ++ value) data |> String.join ", ")
-    in
-    Fix.insertAt
-        { row = insertionPoint.row
-        , column = insertionPoint.column
-        }
-        insertion
-
-
-getFieldNamesAndLastRange : Expression -> ( List String, Range )
-getFieldNamesAndLastRange expr =
-    case expr of
-        TupledExpression expressions ->
-            let
-                lastRange_ =
-                    case expressions |> List.head |> Maybe.map Node.value of
-                        Just expression ->
-                            Install.Library.lastRange expression
-
-                        Nothing ->
-                            Elm.Syntax.Range.empty
-
-                fieldNames_ : List String
-                fieldNames_ =
-                    case expressions |> List.map Node.value |> List.head of
-                        Just recordExpr ->
-                            Install.Library.fieldNames recordExpr
-
-                        Nothing ->
-                            []
-            in
-            ( fieldNames_, lastRange_ )
-
-        LetExpression { expression } ->
-            getFieldNamesAndLastRange (Node.value expression)
-
-        Application children ->
-            children
-                |> List.Extra.find
-                    (\child ->
-                        case Node.value child of
-                            TupledExpression _ ->
-                                True
-
-                            _ ->
-                                False
-                    )
-                |> Maybe.map Node.value
-                |> Maybe.withDefault (TupledExpression [])
-                |> getFieldNamesAndLastRange
-
-        _ ->
-            ( [], Elm.Syntax.Range.empty )

--- a/src/Install/InitializerCmd.elm
+++ b/src/Install/InitializerCmd.elm
@@ -1,26 +1,20 @@
-module Install.InitializerCmd exposing (makeRule)
+module Install.InitializerCmd exposing (config, Config)
 
 {-| Consider a function whose return value is of the form `( _, Cmd.none )`.
 Suppose given a list of commands, e.g. `[foo, bar]`. The function
 `makeRule` described below replaces `Cmd.none` by `Cmd.batch [ foo, bar ]`.
 
-@docs makeRule
+@docs config, Config
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Expression exposing (Expression(..), Function, FunctionImplementation)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range exposing (Range)
-import Install.Library
-import Review.Fix as Fix exposing (Fix)
-import Review.Rule as Rule exposing (Error, Rule)
-import Set exposing (Set)
+import Install.Internal.InitializerCmd as Internal
 
 
-type alias Ignored =
-    Set String
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
 
 
 {-| Consider a function whose return value is of the form `( _, Cmd.none )`.
@@ -28,139 +22,18 @@ Suppose given a list of commands, e.g. `[foo, bar]`. The function
 `makeRule` creates a rule that replaces `Cmd.none` by `Cmd.batch [ foo, bar ]`.
 For example, the rule
 
-    Install.InitializerCmd.makeRule "A.B" "init" [ "foo", "bar" ]
+    Install.InitializerCmd.config "A.B" "init" [ "foo", "bar" ]
+        |> Install.initializerCmd
 
 results in the following fix for function `A.B.init`:
 
     Cmd.none -> (Cmd.batch [ foo, bar ])
 
 -}
-makeRule : String -> String -> List String -> Rule
-makeRule moduleName functionName cmds =
-    let
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor =
-            declarationVisitor moduleName functionName cmds
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.Initializer" contextCreator
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    }
-
-
-contextCreator : Rule.ContextCreator () { moduleName : ModuleName }
-contextCreator =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-
-            -- ...other fields
-            }
-        )
-        |> Rule.withModuleName
-
-
-declarationVisitor : String -> String -> List String -> Node Declaration -> Context -> ( List (Rule.Error {}), Context )
-declarationVisitor moduleName functionName cmds (Node _ declaration) context =
-    case declaration of
-        FunctionDeclaration function ->
-            let
-                name : String
-                name =
-                    Node.value (Node.value function.declaration).name
-            in
-            if name == functionName then
-                let
-                    namespace : String
-                    namespace =
-                        String.join "." context.moduleName ++ "." ++ name
-                in
-                visitCmd namespace moduleName functionName cmds Set.empty function context
-
-            else
-                ( [], context )
-
-        _ ->
-            ( [], context )
-
-
-visitCmd : String -> String -> String -> List String -> Ignored -> Function -> Context -> ( List (Rule.Error {}), Context )
-visitCmd namespace moduleName functionName cmds ignored function context =
-    let
-        declaration : FunctionImplementation
-        declaration =
-            Node.value function.declaration
-
-        isInCorrectModule =
-            Install.Library.isInCorrectModule moduleName context
-
-        ( val, range ) =
-            case declaration.expression |> Node.value of
-                TupledExpression expressions ->
-                    case expressions of
-                        [ _, oldCmds ] ->
-                            let
-                                range_ =
-                                    Node.range oldCmds
-                            in
-                            ( Just oldCmds, range_ )
-
-                        _ ->
-                            ( Nothing, Elm.Syntax.Range.empty )
-
-                _ ->
-                    ( Nothing, Elm.Syntax.Range.empty )
-
-        stringifiedCmds =
-            Maybe.map Install.Library.expressionToString val
-    in
-    if isInCorrectModule && stringifiedCmds == Just "Cmd.none" then
-        ( [ errorWithFix cmds function.declaration (Just range) ], context )
-
-    else
-        ( [], context )
-
-
-
---if isInCorrectModule then
---    ( [ errorWithFix cmds function.declaration (Just lastRange) ], context )
---
---else
---    ( [], context )
-
-
-errorWithFix : List String -> Node a -> Maybe Range -> Error {}
-errorWithFix cmds node errorRange =
-    Rule.errorWithFix
-        { message = "Add cmds " ++ String.join ", " cmds ++ " to the model"
-        , details =
-            [ ""
-            ]
+config : String -> String -> List String -> Config
+config hostModuleName functionName cmds =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , functionName = functionName
+        , cmds = cmds
         }
-        (Node.range node)
-        (case errorRange of
-            Just range ->
-                [ replaceCmds range cmds ]
-
-            Nothing ->
-                []
-        )
-
-
-
---  Cmd.none -> (FunctionOrValue ["Cmd"] "none")
--- hohoho -> (FunctionOrValue [] "hohoho")
-
-
-replaceCmds : Range -> List String -> Fix
-replaceCmds rangeToReplace cmds =
-    let
-        replacement =
-            "Cmd.batch [ " ++ String.join ", " cmds ++ " ]"
-    in
-    Fix.replaceRangeBy rangeToReplace replacement

--- a/src/Install/Internal/ClauseInCase.elm
+++ b/src/Install/Internal/ClauseInCase.elm
@@ -1,0 +1,286 @@
+module Install.Internal.ClauseInCase exposing
+    ( Config(..)
+    , InsertAt(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.Expression exposing (Case, Expression(..), FunctionImplementation)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
+import Elm.Syntax.Range exposing (Range)
+import Install.Library
+import List.Extra
+import Maybe.Extra
+import Review.Fix as Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error)
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , functionName : String
+        , clause : String
+        , functionCall : String
+        , insertAt : InsertAt
+        , customErrorMessage : ErrorMessage
+        }
+
+
+type InsertAt
+    = After String
+    | AtBeginning
+    | AtEnd
+
+
+type alias ErrorMessage =
+    { message : String
+    , details : List String
+    }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Rule.Error {})
+declarationVisitor ((Config { functionName }) as config) (Node _ declaration) =
+    case declaration of
+        FunctionDeclaration function ->
+            if Node.value (Node.value function.declaration).name == functionName then
+                let
+                    functionDeclaration : FunctionImplementation
+                    functionDeclaration =
+                        Node.value function.declaration
+                in
+                visitFunction config functionDeclaration.expression
+
+            else
+                []
+
+        _ ->
+            []
+
+
+visitFunction : Config -> Node Expression -> List (Rule.Error {})
+visitFunction (Config config) expressionNode =
+    let
+        couldNotFindCaseError node =
+            Rule.error
+                { message = "Could not find the case expression"
+                , details = [ "Try to extract the case to a top-level function and call the rule on the new function" ]
+                }
+                (Node.range node)
+    in
+    case findNestedCaseNode expressionNode of
+        Just caseNode ->
+            let
+                caseExpression =
+                    Node.value caseNode
+
+                ( allCases, patternMatchNode ) =
+                    case caseExpression of
+                        CaseExpression { cases, expression } ->
+                            ( cases, expression )
+
+                        -- impossible case
+                        _ ->
+                            ( [], Node.empty caseExpression )
+
+                getPatterns : List Case -> List Pattern
+                getPatterns cases_ =
+                    cases_
+                        |> List.map (\( pattern, _ ) -> Node.value pattern)
+
+                findClause : String -> List Case -> Bool
+                findClause clause_ cases_ =
+                    List.any
+                        (\pattern -> Install.Library.patternToString (Node.empty pattern) == clause_)
+                        (getPatterns cases_)
+            in
+            if not (findClause config.clause allCases) then
+                let
+                    isClauseStringPattern =
+                        List.any isStringPattern (getPatterns allCases)
+
+                    rangeToInsert : Maybe ( Range, Int )
+                    rangeToInsert =
+                        rangeToInsertClause config.insertAt isClauseStringPattern allCases patternMatchNode |> Just
+                in
+                [ errorWithFix config.customErrorMessage isClauseStringPattern config.clause config.functionCall caseNode rangeToInsert ]
+
+            else
+                []
+
+        Nothing ->
+            [ couldNotFindCaseError expressionNode ]
+
+
+rangeToInsertClause : InsertAt -> Bool -> List Case -> Node Expression -> ( Range, Int )
+rangeToInsertClause insertAt isClauseStringPattern cases expression =
+    let
+        lastClauseExpression =
+            cases
+                |> List.Extra.last
+                |> Maybe.map Tuple.second
+                |> Maybe.withDefault expression
+
+        lastClauseStartingColumn =
+            cases
+                |> List.Extra.last
+                |> Maybe.map Tuple.first
+                |> Maybe.map (Node.range >> .start >> .column)
+                |> Maybe.withDefault 0
+                |> (\x -> x - 1)
+    in
+    case insertAt of
+        After previousClause ->
+            let
+                normalizedPreviousClause =
+                    if isClauseStringPattern then
+                        escapeString previousClause
+
+                    else
+                        previousClause
+
+                previousClausePattern =
+                    cases
+                        |> List.Extra.find
+                            (\( pattern, _ ) ->
+                                Install.Library.patternToString pattern == normalizedPreviousClause
+                            )
+            in
+            case previousClausePattern of
+                Just pattern ->
+                    pattern
+                        |> Tuple.second
+                        |> Node.range
+                        |> (\range -> ( range, lastClauseStartingColumn ))
+
+                Nothing ->
+                    ( Node.range lastClauseExpression, 0 )
+
+        AtBeginning ->
+            let
+                -- If there are other clauses, the first clause will take the start of other clauses as reference.
+                otherClausesOffset =
+                    cases
+                        |> List.map (\( pattern, _ ) -> Node.range pattern |> .start |> .column)
+                        |> List.minimum
+                        |> Maybe.map (\x -> x - 1)
+
+                -- If there are no other clauses, the first clause will take the case expression as reference. The -2 is to account for the `case` keyword and the space after it
+                firstClauseOffset =
+                    (Node.range expression).start.column - 2
+
+                clauseOffset =
+                    otherClausesOffset
+                        |> Maybe.withDefault firstClauseOffset
+            in
+            ( Node.range expression, clauseOffset )
+
+        AtEnd ->
+            let
+                range =
+                    Node.range lastClauseExpression
+            in
+            ( range, lastClauseStartingColumn )
+
+
+errorWithFix : ErrorMessage -> Bool -> String -> String -> Node a -> Maybe ( Range, Int ) -> Error {}
+errorWithFix errorMessage isClauseStringPattern clause functionCall node errorRange =
+    Rule.errorWithFix
+        errorMessage
+        (Node.range node)
+        (case errorRange of
+            Just ( range, horizontalOffset ) ->
+                let
+                    insertionPoint =
+                        { row = range.end.row + 1, column = 0 }
+
+                    prefix =
+                        String.repeat horizontalOffset " "
+                in
+                [ addMissingCase insertionPoint isClauseStringPattern prefix clause functionCall ]
+
+            Nothing ->
+                []
+        )
+
+
+addMissingCase : { row : Int, column : Int } -> Bool -> String -> String -> String -> Fix
+addMissingCase { row, column } isClauseStringPattern prefix clause functionCall =
+    let
+        clauseToAdd =
+            if isClauseStringPattern then
+                escapeString clause
+
+            else
+                clause
+
+        insertion =
+            "\n" ++ prefix ++ clauseToAdd ++ " -> " ++ functionCall ++ "\n"
+    in
+    Fix.insertAt { row = row, column = column } insertion
+
+
+
+-- HELPERS
+
+
+findNestedCaseNode : Node Expression -> Maybe (Node Expression)
+findNestedCaseNode node =
+    case Node.value node of
+        CaseExpression _ ->
+            Just node
+
+        Application nodes ->
+            List.Extra.findMap findNestedCaseNode nodes
+
+        OperatorApplication _ _ first second ->
+            Maybe.Extra.orLazy (findNestedCaseNode first) (\_ -> findNestedCaseNode second)
+
+        IfBlock _ thenNode elseNode ->
+            Maybe.Extra.orLazy (findNestedCaseNode thenNode) (\_ -> findNestedCaseNode elseNode)
+
+        Negation nestedNode ->
+            findNestedCaseNode nestedNode
+
+        TupledExpression nodes ->
+            List.Extra.findMap findNestedCaseNode nodes
+
+        ParenthesizedExpression nestedNode ->
+            findNestedCaseNode nestedNode
+
+        LetExpression { expression } ->
+            findNestedCaseNode expression
+
+        LambdaExpression { expression } ->
+            findNestedCaseNode expression
+
+        ListExpr nodes ->
+            List.Extra.findMap findNestedCaseNode nodes
+
+        _ ->
+            Nothing
+
+
+isStringPattern : Pattern -> Bool
+isStringPattern pattern =
+    case pattern of
+        StringPattern _ ->
+            True
+
+        _ ->
+            False
+
+
+escapeString : String -> String
+escapeString str =
+    if isStringScaped str then
+        str
+
+    else
+        "\"" ++ str ++ "\""
+
+
+isStringScaped : String -> Bool
+isStringScaped str =
+    String.startsWith "\\" str

--- a/src/Install/Internal/ElementToList.elm
+++ b/src/Install/Internal/ElementToList.elm
@@ -1,0 +1,105 @@
+module Install.Internal.ElementToList exposing
+    ( Config(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.Expression exposing (Expression(..))
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Range exposing (Location)
+import Install.Library
+import Review.Fix as Fix
+import Review.Rule as Rule
+import String.Extra
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , functionName : String
+        , elements : List String
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Rule.Error {})
+declarationVisitor (Config config) (Node _ declaration) =
+    case declaration of
+        FunctionDeclaration function ->
+            if Install.Library.isInCorrectFunction config.functionName function then
+                let
+                    implementation =
+                        Node.value function.declaration
+
+                    expr =
+                        implementation.expression
+
+                    data =
+                        case Node.value expr of
+                            ListExpr nodes ->
+                                Just nodes
+
+                            _ ->
+                                Nothing
+                in
+                case data of
+                    Nothing ->
+                        []
+
+                    Just listElements ->
+                        let
+                            isAlreadyImplemented =
+                                Install.Library.areItemsInList config.elements listElements
+                        in
+                        if isAlreadyImplemented then
+                            []
+
+                        else
+                            let
+                                replacementCode =
+                                    config.elements
+                                        |> List.map (\item -> ", " ++ item)
+                                        |> String.concat
+
+                                lastElementLocation =
+                                    listElements
+                                        |> List.reverse
+                                        |> List.head
+                                        |> Maybe.map (Node.range >> .end)
+                                        |> Maybe.withDefault (Node.range expr).start
+                            in
+                            [ errorWithFix replacementCode expr lastElementLocation ]
+
+            else
+                []
+
+        _ ->
+            []
+
+
+errorWithFix : String -> Node Expression -> Location -> Rule.Error {}
+errorWithFix replacementCode expression lastElementLocation =
+    let
+        numberOfElementsAdded =
+            String.Extra.countOccurrences ", " replacementCode
+
+        replacementText =
+            if numberOfElementsAdded == 1 then
+                "1 element"
+
+            else
+                String.fromInt numberOfElementsAdded ++ " elements"
+    in
+    Rule.errorWithFix
+        { message = "Add " ++ replacementText ++ " to the list"
+        , details =
+            [ ""
+            ]
+        }
+        (Node.range expression)
+        [ Fix.insertAt
+            { row = lastElementLocation.row
+            , column = lastElementLocation.column
+            }
+            (String.Extra.clean replacementCode)
+        ]

--- a/src/Install/Internal/FieldInTypeAlias.elm
+++ b/src/Install/Internal/FieldInTypeAlias.elm
@@ -1,0 +1,128 @@
+module Install.Internal.FieldInTypeAlias exposing (Config(..), declarationVisitor, getFieldName)
+
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range exposing (Range)
+import Elm.Syntax.TypeAnnotation as TypeAnnotation
+import Review.Fix as Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error)
+import Set exposing (Set)
+import Set.Extra
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , typeName : String
+        , fieldDefinitions : List String
+        , fieldNames : Set String
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Error {})
+declarationVisitor (Config { typeName, fieldNames, fieldDefinitions }) node =
+    case Node.value node of
+        Declaration.AliasDeclaration type_ ->
+            let
+                fieldsOfNode : Node Declaration -> List String
+                fieldsOfNode node_ =
+                    case Node.value node_ of
+                        Declaration.AliasDeclaration typeAlias ->
+                            case typeAlias.typeAnnotation |> Node.value of
+                                TypeAnnotation.Record fields ->
+                                    fields
+                                        |> List.map (Node.value >> Tuple.first >> Node.value)
+
+                                _ ->
+                                    []
+
+                        _ ->
+                            []
+
+                shouldFix : Node Declaration -> Bool
+                shouldFix node_ =
+                    let
+                        fieldsOfNode_ =
+                            fieldsOfNode node_
+                    in
+                    not <| Set.Extra.isSubsetOf (Set.fromList fieldsOfNode_) fieldNames
+            in
+            if Node.value type_.name == typeName && shouldFix node then
+                let
+                    fieldsToAdd : Set String
+                    fieldsToAdd =
+                        Set.diff fieldNames (Set.fromList <| fieldsOfNode node)
+
+                    getFieldCode field =
+                        "    , " ++ field ++ "\n"
+
+                    closeRecord =
+                        "    }"
+
+                    -- filter out the fields that are already in the type alias
+                    newFields : List String
+                    newFields =
+                        fieldDefinitions
+                            |> List.filter (\field -> Set.member (getFieldName field) fieldsToAdd)
+
+                    fieldsCode =
+                        newFields
+                            |> List.map getFieldCode
+                            |> String.concat
+                            |> (\fields -> fields ++ closeRecord)
+                in
+                [ errorWithFix typeName fieldsToAdd fieldsCode node (Just <| Node.range node) ]
+
+            else
+                []
+
+        _ ->
+            []
+
+
+errorWithFix : String -> Set String -> String -> Node a -> Maybe Range -> Error {}
+errorWithFix typeName_ fieldsName fieldCode node errorRange =
+    let
+        fieldsNameList =
+            Set.toList fieldsName
+
+        fieldName =
+            case fieldsNameList of
+                [ field ] ->
+                    field
+
+                _ ->
+                    "fields " ++ String.join ", " fieldsNameList
+    in
+    Rule.errorWithFix
+        { message = "Add " ++ fieldName ++ " to " ++ typeName_
+        , details =
+            [ "" ]
+        }
+        (Node.range node)
+        (case errorRange of
+            Just range ->
+                [ fixMissingField range.end fieldCode ]
+
+            Nothing ->
+                []
+        )
+
+
+fixMissingField : { row : Int, column : Int } -> String -> Fix
+fixMissingField { row, column } fieldCode =
+    let
+        range =
+            { start = { row = row, column = 0 }, end = { row = row, column = column } }
+    in
+    Fix.replaceRangeBy range fieldCode
+
+
+getFieldName : String -> String
+getFieldName field =
+    field
+        |> String.split ":"
+        |> List.head
+        |> Maybe.withDefault ""
+        |> String.trim

--- a/src/Install/Internal/Import.elm
+++ b/src/Install/Internal/Import.elm
@@ -32,17 +32,15 @@ type alias ImportedModule =
 
 
 type alias Context =
-    { moduleName : ModuleName
-    , moduleWasImported : Bool
+    { moduleWasImported : Bool
     , lastNodeRange : Range
     , foundImports : List (List String)
     }
 
 
-init : ModuleName -> Context
-init moduleName =
-    { moduleName = moduleName
-    , moduleWasImported = False
+init : Context
+init =
+    { moduleWasImported = False
     , lastNodeRange = Range.empty
     , foundImports = []
     }
@@ -80,14 +78,14 @@ moduleDefinitionVisitor def context =
 finalEvaluation : Config -> Context -> List (Rule.Error {})
 finalEvaluation (Config config) context =
     if context.moduleWasImported == False then
-        fixError config.imports context
+        fixError config.hostModuleName config.imports context
 
     else
         []
 
 
-fixError : List ImportedModule -> Context -> List (Error {})
-fixError imports context =
+fixError : ModuleName -> List ImportedModule -> Context -> List (Error {})
+fixError hostModuleName imports context =
     let
         importText moduleToImport importedModuleAlias exposedValues =
             "import "
@@ -124,7 +122,7 @@ fixError imports context =
             List.length uniqueImports
 
         moduleName =
-            context.moduleName |> String.join "."
+            hostModuleName |> String.join "."
 
         numberOfImportsText =
             if numberOfImports == 1 then

--- a/src/Install/Internal/Import.elm
+++ b/src/Install/Internal/Import.elm
@@ -50,29 +50,25 @@ init moduleName =
 
 importVisitor : Config -> Node Import -> Context -> Context
 importVisitor (Config config) node context =
-    if config.hostModuleName == context.moduleName then
-        let
-            currentModuleName : ModuleName
-            currentModuleName =
-                Node.value node |> .moduleName |> Node.value
+    let
+        currentModuleName : ModuleName
+        currentModuleName =
+            Node.value node |> .moduleName |> Node.value
 
-            allModuleNames =
-                List.map .moduleToImport config.imports
+        allModuleNames =
+            List.map .moduleToImport config.imports
 
-            foundImports =
-                currentModuleName :: context.foundImports
+        foundImports =
+            currentModuleName :: context.foundImports
 
-            areAllImportsFound =
-                List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
-        in
-        if areAllImportsFound then
-            { context | moduleWasImported = True, lastNodeRange = Node.range node }
-
-        else
-            { context | lastNodeRange = Node.range node, foundImports = foundImports }
+        areAllImportsFound =
+            List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
+    in
+    if areAllImportsFound then
+        { context | moduleWasImported = True, lastNodeRange = Node.range node }
 
     else
-        context
+        { context | lastNodeRange = Node.range node, foundImports = foundImports }
 
 
 moduleDefinitionVisitor : Node Module -> Context -> Context
@@ -83,7 +79,7 @@ moduleDefinitionVisitor def context =
 
 finalEvaluation : Config -> Context -> List (Rule.Error {})
 finalEvaluation (Config config) context =
-    if context.moduleWasImported == False && config.hostModuleName == context.moduleName then
+    if context.moduleWasImported == False then
         fixError config.imports context
 
     else

--- a/src/Install/Internal/Import.elm
+++ b/src/Install/Internal/Import.elm
@@ -1,0 +1,144 @@
+module Install.Internal.Import exposing
+    ( Config(..)
+    , Context
+    , ImportedModule
+    , finalEvaluation
+    , importVisitor
+    , init
+    , moduleDefinitionVisitor
+    )
+
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.Module exposing (Module)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range as Range exposing (Range)
+import Review.Fix as Fix
+import Review.Rule as Rule exposing (Error)
+
+
+type Config
+    = Config
+        { hostModuleName : List String
+        , imports : List ImportedModule
+        }
+
+
+type alias ImportedModule =
+    { moduleToImport : ModuleName
+    , alias : Maybe String
+    , exposedValues : Maybe (List String)
+    }
+
+
+type alias Context =
+    { moduleName : ModuleName
+    , moduleWasImported : Bool
+    , lastNodeRange : Range
+    , foundImports : List (List String)
+    }
+
+
+init : ModuleName -> Context
+init moduleName =
+    { moduleName = moduleName
+    , moduleWasImported = False
+    , lastNodeRange = Range.empty
+    , foundImports = []
+    }
+
+
+importVisitor : Config -> Node Import -> Context -> Context
+importVisitor (Config config) node context =
+    if config.hostModuleName == context.moduleName then
+        let
+            currentModuleName : ModuleName
+            currentModuleName =
+                Node.value node |> .moduleName |> Node.value
+
+            allModuleNames =
+                List.map .moduleToImport config.imports
+
+            foundImports =
+                currentModuleName :: context.foundImports
+
+            areAllImportsFound =
+                List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
+        in
+        if areAllImportsFound then
+            { context | moduleWasImported = True, lastNodeRange = Node.range node }
+
+        else
+            { context | lastNodeRange = Node.range node, foundImports = foundImports }
+
+    else
+        context
+
+
+moduleDefinitionVisitor : Node Module -> Context -> Context
+moduleDefinitionVisitor def context =
+    -- visit the module definition to set the module definition as the lastNodeRange in case the module has no imports yet
+    { context | lastNodeRange = Node.range def }
+
+
+finalEvaluation : Config -> Context -> List (Rule.Error {})
+finalEvaluation (Config config) context =
+    if context.moduleWasImported == False && config.hostModuleName == context.moduleName then
+        fixError config.imports context
+
+    else
+        []
+
+
+fixError : List ImportedModule -> Context -> List (Error {})
+fixError imports context =
+    let
+        importText moduleToImport importedModuleAlias exposedValues =
+            "import "
+                ++ String.join "." moduleToImport
+                |> addAlias importedModuleAlias
+                |> addExposing exposedValues
+
+        uniqueImports =
+            List.filter (\importedModule -> not (List.member importedModule.moduleToImport context.foundImports)) imports
+
+        allImports =
+            List.map (\{ moduleToImport, alias, exposedValues } -> importText moduleToImport alias exposedValues) uniqueImports
+                |> String.join "\n"
+
+        addAlias : Maybe String -> String -> String
+        addAlias mAlias str =
+            case mAlias of
+                Nothing ->
+                    str
+
+                Just alias ->
+                    str ++ " as " ++ alias
+
+        addExposing : Maybe (List String) -> String -> String
+        addExposing mExposedValues str =
+            case mExposedValues of
+                Nothing ->
+                    str
+
+                Just exposedValues ->
+                    str ++ " exposing (" ++ String.join ", " exposedValues ++ ")"
+
+        numberOfImports =
+            List.length uniqueImports
+
+        moduleName =
+            context.moduleName |> String.join "."
+
+        numberOfImportsText =
+            if numberOfImports == 1 then
+                String.fromInt numberOfImports ++ " import"
+
+            else
+                String.fromInt numberOfImports ++ " imports"
+    in
+    [ Rule.errorWithFix
+        { message = "add " ++ numberOfImportsText ++ " to module " ++ moduleName, details = [ "" ] }
+        context.lastNodeRange
+        [ Fix.insertAt { row = context.lastNodeRange.end.row + 1, column = context.lastNodeRange.end.column } allImports ]
+    ]

--- a/src/Install/Internal/Initializer.elm
+++ b/src/Install/Internal/Initializer.elm
@@ -106,7 +106,7 @@ getFieldNamesAndLastRange expr =
     case expr of
         TupledExpression expressions ->
             let
-                lastRange_ =
+                lastRange =
                     case expressions |> List.head |> Maybe.map Node.value of
                         Just expression ->
                             Install.Library.lastRange expression
@@ -114,16 +114,16 @@ getFieldNamesAndLastRange expr =
                         Nothing ->
                             Elm.Syntax.Range.empty
 
-                fieldNames_ : List String
-                fieldNames_ =
-                    case expressions |> List.map Node.value |> List.head of
-                        Just recordExpr ->
+                fieldNames : List String
+                fieldNames =
+                    case List.head expressions of
+                        Just (Node _ recordExpr) ->
                             Install.Library.fieldNames recordExpr
 
                         Nothing ->
                             []
             in
-            ( fieldNames_, lastRange_ )
+            ( fieldNames, lastRange )
 
         LetExpression { expression } ->
             getFieldNamesAndLastRange (Node.value expression)

--- a/src/Install/Internal/Initializer.elm
+++ b/src/Install/Internal/Initializer.elm
@@ -1,0 +1,147 @@
+module Install.Internal.Initializer exposing
+    ( Config(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.Expression exposing (Expression(..), Function, FunctionImplementation)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Range exposing (Range)
+import Install.Library
+import List.Extra
+import Review.Fix as Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error)
+import Set
+import Set.Extra
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , functionName : String
+        , data : List { field : String, value : String }
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Rule.Error {})
+declarationVisitor (Config { data, functionName }) (Node _ declaration) =
+    case declaration of
+        FunctionDeclaration function ->
+            let
+                name : String
+                name =
+                    Node.value (Node.value function.declaration).name
+            in
+            if name == functionName then
+                visitFunction data function
+
+            else
+                []
+
+        _ ->
+            []
+
+
+visitFunction : List { field : String, value : String } -> Function -> List (Rule.Error {})
+visitFunction data function =
+    let
+        declaration : FunctionImplementation
+        declaration =
+            Node.value function.declaration
+
+        ( fieldNames, lastRange ) =
+            getFieldNamesAndLastRange (Node.value declaration.expression)
+
+        existingFields =
+            Set.fromList fieldNames
+
+        newFields =
+            List.map .field data |> Set.fromList
+    in
+    if not <| Set.Extra.isSubsetOf existingFields newFields then
+        [ errorWithFix data function.declaration (Just lastRange) ]
+
+    else
+        []
+
+
+errorWithFix : List { field : String, value : String } -> Node a -> Maybe Range -> Error {}
+errorWithFix data node errorRange =
+    Rule.errorWithFix
+        { message = "Add fields to the model"
+        , details =
+            [ ""
+            ]
+        }
+        (Node.range node)
+        (case errorRange of
+            Just range ->
+                let
+                    insertionPoint =
+                        { row = range.end.row, column = range.end.column }
+                in
+                [ addMissingCases insertionPoint data ]
+
+            Nothing ->
+                []
+        )
+
+
+addMissingCases : { row : Int, column : Int } -> List { field : String, value : String } -> Fix
+addMissingCases insertionPoint data =
+    let
+        insertion =
+            ", " ++ (List.map (\{ field, value } -> field ++ " = " ++ value) data |> String.join ", ")
+    in
+    Fix.insertAt
+        { row = insertionPoint.row
+        , column = insertionPoint.column
+        }
+        insertion
+
+
+getFieldNamesAndLastRange : Expression -> ( List String, Range )
+getFieldNamesAndLastRange expr =
+    case expr of
+        TupledExpression expressions ->
+            let
+                lastRange_ =
+                    case expressions |> List.head |> Maybe.map Node.value of
+                        Just expression ->
+                            Install.Library.lastRange expression
+
+                        Nothing ->
+                            Elm.Syntax.Range.empty
+
+                fieldNames_ : List String
+                fieldNames_ =
+                    case expressions |> List.map Node.value |> List.head of
+                        Just recordExpr ->
+                            Install.Library.fieldNames recordExpr
+
+                        Nothing ->
+                            []
+            in
+            ( fieldNames_, lastRange_ )
+
+        LetExpression { expression } ->
+            getFieldNamesAndLastRange (Node.value expression)
+
+        Application children ->
+            children
+                |> List.Extra.find
+                    (\child ->
+                        case Node.value child of
+                            TupledExpression _ ->
+                                True
+
+                            _ ->
+                                False
+                    )
+                |> Maybe.map Node.value
+                |> Maybe.withDefault (TupledExpression [])
+                |> getFieldNamesAndLastRange
+
+        _ ->
+            ( [], Elm.Syntax.Range.empty )

--- a/src/Install/Internal/InitializerCmd.elm
+++ b/src/Install/Internal/InitializerCmd.elm
@@ -1,0 +1,106 @@
+module Install.Internal.InitializerCmd exposing
+    ( Config(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.Expression exposing (Expression(..), Function, FunctionImplementation)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Range exposing (Range)
+import Install.Library
+import Review.Fix as Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error)
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , functionName : String
+        , cmds : List String
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Rule.Error {})
+declarationVisitor (Config config) (Node _ declaration) =
+    case declaration of
+        FunctionDeclaration function ->
+            let
+                name : String
+                name =
+                    Node.value (Node.value function.declaration).name
+            in
+            if name == config.functionName then
+                visitCmd config.cmds function
+
+            else
+                []
+
+        _ ->
+            []
+
+
+visitCmd : List String -> Function -> List (Rule.Error {})
+visitCmd cmds function =
+    let
+        declaration : FunctionImplementation
+        declaration =
+            Node.value function.declaration
+
+        ( val, range ) =
+            case declaration.expression |> Node.value of
+                TupledExpression expressions ->
+                    case expressions of
+                        [ _, oldCmds ] ->
+                            let
+                                range_ =
+                                    Node.range oldCmds
+                            in
+                            ( Just oldCmds, range_ )
+
+                        _ ->
+                            ( Nothing, Elm.Syntax.Range.empty )
+
+                _ ->
+                    ( Nothing, Elm.Syntax.Range.empty )
+
+        stringifiedCmds =
+            Maybe.map Install.Library.expressionToString val
+    in
+    if stringifiedCmds == Just "Cmd.none" then
+        [ errorWithFix cmds function.declaration (Just range) ]
+
+    else
+        []
+
+
+errorWithFix : List String -> Node a -> Maybe Range -> Error {}
+errorWithFix cmds node errorRange =
+    Rule.errorWithFix
+        { message = "Add cmds " ++ String.join ", " cmds ++ " to the model"
+        , details =
+            [ ""
+            ]
+        }
+        (Node.range node)
+        (case errorRange of
+            Just range ->
+                [ replaceCmds range cmds ]
+
+            Nothing ->
+                []
+        )
+
+
+
+--  Cmd.none -> (FunctionOrValue ["Cmd"] "none")
+-- hohoho -> (FunctionOrValue [] "hohoho")
+
+
+replaceCmds : Range -> List String -> Fix
+replaceCmds rangeToReplace cmds =
+    let
+        replacement =
+            "Cmd.batch [ " ++ String.join ", " cmds ++ " ]"
+    in
+    Fix.replaceRangeBy rangeToReplace replacement

--- a/src/Install/Internal/InsertFunction.elm
+++ b/src/Install/Internal/InsertFunction.elm
@@ -1,0 +1,92 @@
+module Install.Internal.InsertFunction exposing
+    ( Config(..)
+    , Context
+    , InsertAt(..)
+    , declarationVisitor
+    , finalEvaluation
+    , init
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration)
+import Elm.Syntax.Expression exposing (Expression)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range as Range exposing (Range)
+import Install.Library
+import Review.Fix as Fix
+import Review.Rule as Rule exposing (Error)
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , functionName : String
+        , functionImplementation : String
+        , theFunctionNodeExpression : Maybe (Node Expression)
+        , insertAt : InsertAt
+        }
+
+
+type InsertAt
+    = After String
+    | AtEnd
+
+
+type alias Context =
+    { lastDeclarationRange : Range
+    , appliedFix : Bool
+    }
+
+
+init : Context
+init =
+    { lastDeclarationRange = Range.empty
+    , appliedFix = False
+    }
+
+
+declarationVisitor : Config -> Node Declaration -> Context -> Context
+declarationVisitor (Config config) declaration context =
+    let
+        declarationName =
+            Install.Library.getDeclarationName declaration
+    in
+    if declarationName == config.functionName then
+        { context | appliedFix = True }
+
+    else
+        case config.insertAt of
+            After previousDeclaration ->
+                if Install.Library.getDeclarationName declaration == previousDeclaration then
+                    { context | lastDeclarationRange = Node.range declaration }
+
+                else
+                    context
+
+            AtEnd ->
+                { context | lastDeclarationRange = Node.range declaration }
+
+
+finalEvaluation : Config -> Context -> List (Rule.Error {})
+finalEvaluation (Config config) context =
+    if not context.appliedFix then
+        addFunction { range = context.lastDeclarationRange, functionName = config.functionName, functionImplementation = config.functionImplementation }
+
+    else
+        []
+
+
+type alias FixConfig =
+    { range : Range
+    , functionName : String
+    , functionImplementation : String
+    }
+
+
+addFunction : FixConfig -> List (Error {})
+addFunction fixConfig =
+    [ Rule.errorWithFix
+        { message = "Add function \"" ++ fixConfig.functionName ++ "\"", details = [ "" ] }
+        fixConfig.range
+        [ Fix.insertAt { row = fixConfig.range.end.row + 1, column = 0 } fixConfig.functionImplementation ]
+    ]

--- a/src/Install/Internal/InsertFunction.elm
+++ b/src/Install/Internal/InsertFunction.elm
@@ -8,7 +8,6 @@ module Install.Internal.InsertFunction exposing
     )
 
 import Elm.Syntax.Declaration exposing (Declaration)
-import Elm.Syntax.Expression exposing (Expression)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range as Range exposing (Range)
@@ -22,7 +21,6 @@ type Config
         { hostModuleName : ModuleName
         , functionName : String
         , functionImplementation : String
-        , theFunctionNodeExpression : Maybe (Node Expression)
         , insertAt : InsertAt
         }
 

--- a/src/Install/Internal/InsertFunction.elm
+++ b/src/Install/Internal/InsertFunction.elm
@@ -13,7 +13,7 @@ import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range as Range exposing (Range)
 import Install.Library
 import Review.Fix as Fix
-import Review.Rule as Rule exposing (Error)
+import Review.Rule as Rule
 
 
 type Config
@@ -68,23 +68,11 @@ declarationVisitor (Config config) declaration context =
 finalEvaluation : Config -> Context -> List (Rule.Error {})
 finalEvaluation (Config config) context =
     if not context.appliedFix then
-        addFunction { range = context.lastDeclarationRange, functionName = config.functionName, functionImplementation = config.functionImplementation }
+        [ Rule.errorWithFix
+            { message = "Add function \"" ++ config.functionName ++ "\"", details = [ "" ] }
+            context.lastDeclarationRange
+            [ Fix.insertAt { row = context.lastDeclarationRange.end.row + 1, column = 0 } config.functionImplementation ]
+        ]
 
     else
         []
-
-
-type alias FixConfig =
-    { range : Range
-    , functionName : String
-    , functionImplementation : String
-    }
-
-
-addFunction : FixConfig -> List (Error {})
-addFunction fixConfig =
-    [ Rule.errorWithFix
-        { message = "Add function \"" ++ fixConfig.functionName ++ "\"", details = [ "" ] }
-        fixConfig.range
-        [ Fix.insertAt { row = fixConfig.range.end.row + 1, column = 0 } fixConfig.functionImplementation ]
-    ]

--- a/src/Install/Internal/ReplaceFunction.elm
+++ b/src/Install/Internal/ReplaceFunction.elm
@@ -1,0 +1,48 @@
+module Install.Internal.ReplaceFunction exposing
+    ( Config(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range exposing (Range)
+import Install.Library
+import Review.Fix as Fix
+import Review.Rule as Rule
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , functionName : String
+        , functionImplementation : String
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Rule.Error {})
+declarationVisitor (Config config) declaration =
+    case Node.value declaration of
+        FunctionDeclaration _ ->
+            if
+                (Install.Library.getDeclarationName declaration == config.functionName)
+                    && (not <| Install.Library.isStringEqualToDeclaration config.functionImplementation declaration)
+            then
+                let
+                    range : Range
+                    range =
+                        Node.range declaration
+                in
+                [ Rule.errorWithFix
+                    { message = "Replace function \"" ++ config.functionName ++ "\""
+                    , details = [ "" ]
+                    }
+                    range
+                    [ Fix.replaceRangeBy range config.functionImplementation ]
+                ]
+
+            else
+                []
+
+        _ ->
+            []

--- a/src/Install/Internal/Subscription.elm
+++ b/src/Install/Internal/Subscription.elm
@@ -1,0 +1,95 @@
+module Install.Internal.Subscription exposing
+    ( Config(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration exposing (Declaration(..))
+import Elm.Syntax.Expression exposing (Expression(..))
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Range exposing (Location, Range)
+import Install.Library
+import Review.Fix as Fix
+import Review.Rule as Rule exposing (Error)
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , subscriptions : List String
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Rule.Error {})
+declarationVisitor (Config config) (Node _ declaration) =
+    case declaration of
+        FunctionDeclaration function ->
+            let
+                implementation =
+                    Node.value function.declaration
+
+                name : String
+                name =
+                    Node.value implementation.name
+            in
+            if name /= "subscriptions" then
+                []
+
+            else
+                case Node.value implementation.expression of
+                    Application ((Node _ (FunctionOrValue [ "Sub" ] "batch")) :: rest) ->
+                        let
+                            listElements =
+                                rest
+                                    |> List.head
+                                    |> Maybe.map Node.value
+                                    |> (\expression ->
+                                            case expression of
+                                                Just (ListExpr exprs) ->
+                                                    exprs
+
+                                                _ ->
+                                                    []
+                                       )
+
+                            isAlreadyImplemented =
+                                Install.Library.areItemsInList config.subscriptions listElements
+                        in
+                        if isAlreadyImplemented then
+                            []
+
+                        else
+                            let
+                                expr =
+                                    implementation.expression
+
+                                endOfRange =
+                                    (Node.range expr).end
+
+                                nameRange =
+                                    Node.range implementation.name
+
+                                replacementCode =
+                                    config.subscriptions
+                                        |> List.map (\item -> ", " ++ item)
+                                        |> String.concat
+                            in
+                            [ errorWithFix replacementCode nameRange endOfRange ]
+
+                    _ ->
+                        []
+
+        _ ->
+            []
+
+
+errorWithFix : String -> Range -> Location -> Error {}
+errorWithFix replacementCode range endRange =
+    Rule.errorWithFix
+        { message = "Add to subscriptions: " ++ replacementCode
+        , details =
+            [ ""
+            ]
+        }
+        range
+        [ Fix.insertAt { endRange | column = endRange.column - 2 } replacementCode ]

--- a/src/Install/Internal/Type.elm
+++ b/src/Install/Internal/Type.elm
@@ -1,0 +1,89 @@
+module Install.Internal.Type exposing
+    ( Config(..)
+    , Context
+    , declarationVisitor
+    , finalEvaluation
+    , importVisitor
+    , init
+    )
+
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range as Range exposing (Range)
+import List.Extra
+import Review.Fix as Fix
+import Review.Rule as Rule exposing (Error)
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , typeName : String
+        , variants : List String
+        }
+
+
+type alias Context =
+    { typeIsPresent : Bool
+    , lastNodeRange : Range
+    }
+
+
+init : Context
+init =
+    { typeIsPresent = False
+    , lastNodeRange = Range.empty
+    }
+
+
+importVisitor : Node Import -> Context -> Context
+importVisitor node context =
+    { context | lastNodeRange = Node.range node }
+
+
+declarationVisitor : Config -> Node Declaration -> Context -> Context
+declarationVisitor (Config config) node context =
+    case Node.value node of
+        Declaration.CustomTypeDeclaration type_ ->
+            if Node.value type_.name == config.typeName then
+                { context | typeIsPresent = True, lastNodeRange = Node.range node }
+
+            else
+                { context | lastNodeRange = Node.range node }
+
+        _ ->
+            context
+
+
+finalEvaluation : Config -> Context -> List (Rule.Error {})
+finalEvaluation (Config config) context =
+    if context.typeIsPresent == False then
+        fixError config.typeName config.variants context
+
+    else
+        []
+
+
+fixError : String -> List String -> Context -> List (Error {})
+fixError typeName_ variants_ context =
+    let
+        codeToAdd =
+            case List.Extra.uncons variants_ of
+                Nothing ->
+                    ""
+
+                Just ( head, tail ) ->
+                    "\n"
+                        ++ (String.join "  " [ "type", typeName_, "=" ]
+                                :: ("    " ++ head)
+                                :: List.map (\s -> "  | " ++ s) tail
+                                |> String.join "\n"
+                           )
+    in
+    [ Rule.errorWithFix
+        { message = "add type: \"" ++ typeName_, details = [ "" ] }
+        context.lastNodeRange
+        [ Fix.insertAt { row = context.lastNodeRange.end.row + 2, column = 0 } codeToAdd ]
+    ]

--- a/src/Install/Internal/TypeVariant.elm
+++ b/src/Install/Internal/TypeVariant.elm
@@ -1,0 +1,89 @@
+module Install.Internal.TypeVariant exposing
+    ( Config(..)
+    , declarationVisitor
+    )
+
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range exposing (Range)
+import Review.Fix as Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error, Rule)
+import Set exposing (Set)
+import Set.Extra
+
+
+type Config
+    = Config
+        { hostModuleName : ModuleName
+        , typeName : String
+        , variants : List String
+        }
+
+
+declarationVisitor : Config -> Node Declaration -> List (Error {})
+declarationVisitor (Config config) node =
+    case Node.value node of
+        Declaration.CustomTypeDeclaration type_ ->
+            let
+                variantName : String -> Maybe String
+                variantName variantString =
+                    variantString |> String.split " " |> List.head |> Maybe.map String.trim
+
+                variantCodeItem variantString =
+                    "\n    | " ++ variantString
+
+                variantNames =
+                    List.filterMap variantName config.variants
+
+                shouldFix : Node Declaration -> Bool
+                shouldFix node_ =
+                    let
+                        variantsOfNode : Set String
+                        variantsOfNode =
+                            case Node.value node_ of
+                                Declaration.CustomTypeDeclaration type__ ->
+                                    type__.constructors
+                                        |> List.map (Node.value >> .name >> Node.value)
+                                        |> Set.fromList
+
+                                _ ->
+                                    Set.empty
+                    in
+                    not <| Set.Extra.isSubsetOf variantsOfNode (Set.fromList variantNames)
+            in
+            if Node.value type_.name == config.typeName && shouldFix node then
+                let
+                    variantCode =
+                        List.map variantCodeItem config.variants |> String.concat
+                in
+                [ errorWithFix config.typeName variantNames variantCode node (Just <| Node.range node) ]
+
+            else
+                []
+
+        _ ->
+            []
+
+
+errorWithFix : String -> List String -> String -> Node a -> Maybe Range -> Error {}
+errorWithFix typeName_ variantNames variantCode node errorRange =
+    Rule.errorWithFix
+        { message = "Add variants [" ++ String.join ", " variantNames ++ "] to " ++ typeName_
+        , details =
+            [ ""
+            ]
+        }
+        (Node.range node)
+        (case errorRange of
+            Just range ->
+                [ fixMissingVariant range.end variantCode ]
+
+            Nothing ->
+                []
+        )
+
+
+fixMissingVariant : { row : Int, column : Int } -> String -> Fix
+fixMissingVariant { row, column } variantCode =
+    Fix.insertAt { row = row, column = column } variantCode

--- a/src/Install/Library.elm
+++ b/src/Install/Library.elm
@@ -8,7 +8,7 @@ import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..))
 import Elm.Syntax.Range as Range exposing (Range)
 import List.Extra
-import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
+import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule
 import Set exposing (Set)
 import Set.Extra as Set
@@ -129,23 +129,8 @@ extractNamesFromPattern (Node _ pattern) set =
 
 
 visitExpression : String -> Ignored -> Node Expression -> ModuleContext -> ModuleContext
-visitExpression namespace ignored ((Node _ expression) as expressionNode) context =
+visitExpression namespace ignored (Node _ expression) context =
     case expression of
-        FunctionOrValue moduleName name ->
-            case ModuleNameLookupTable.fullModuleNameFor context.lookupTable expressionNode of
-                Nothing ->
-                    context
-
-                Just fullModuleName ->
-                    if
-                        List.isEmpty moduleName && Set.member name ignored
-                        --|| Set.member fullModuleNameJoined coreModules
-                    then
-                        context
-
-                    else
-                        context
-
         IfBlock c t f ->
             visitExpressions namespace ignored [ c, t, f ] context
 
@@ -295,7 +280,7 @@ getDeclarationName : Node Declaration -> String
 getDeclarationName declaration =
     let
         getName declaration_ =
-            declaration_ |> .name >> Node.value
+            declaration_ |> .name |> Node.value
     in
     case Node.value declaration of
         FunctionDeclaration function ->
@@ -513,7 +498,7 @@ isStringEqualToDeclaration str decl =
                                 else
                                     lines
                    )
-                |> String.join ""
+                |> String.concat
     in
     (declarationToString >> deepCleanString) decl == (removeTypeAnnotation >> deepCleanString) str
 

--- a/src/Install/Rule.elm
+++ b/src/Install/Rule.elm
@@ -1,4 +1,17 @@
-module Install.Rule exposing (Installation, rule)
+module Install.Rule exposing
+    ( rule
+    , Installation
+    , addImport
+    )
+
+{-| TODO REPLACEME
+
+@docs rule
+
+@docs Installation
+@docs addImport
+
+-}
 
 import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.Module exposing (Module)
@@ -16,6 +29,13 @@ type alias Context =
 -}
 type Installation
     = AddImport Install.Import.Config
+
+
+{-| Add an import defined by [Install-Import#config].
+-}
+addImport : Install.Import.Config -> Installation
+addImport =
+    AddImport
 
 
 {-| Create a rule from a list of transformations.

--- a/src/Install/Rule.elm
+++ b/src/Install/Rule.elm
@@ -58,8 +58,12 @@ initContext installations =
             List.foldl
                 (\installation context ->
                     case installation of
-                        AddImport config ->
-                            { context | importContexts = ( config, Install.Internal.Import.init moduleName ) :: context.importContexts }
+                        AddImport ((Install.Internal.Import.Config { hostModuleName }) as config) ->
+                            if moduleName == hostModuleName then
+                                { context | importContexts = ( config, Install.Internal.Import.init moduleName ) :: context.importContexts }
+
+                            else
+                                context
                 )
                 { importContexts = []
                 }

--- a/src/Install/Rule.elm
+++ b/src/Install/Rule.elm
@@ -16,24 +16,25 @@ module Install.Rule exposing
 import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.Module exposing (Module)
 import Elm.Syntax.Node exposing (Node)
-import Install.Import
+import Install.Import as Import
+import Install.Internal.Import
 import Review.Rule as Rule exposing (Error, Rule)
 
 
 type alias Context =
-    { importContexts : List ( Install.Import.Config, Install.Import.Context )
+    { importContexts : List ( Install.Internal.Import.Config, Install.Internal.Import.Context )
     }
 
 
 {-| A transformation to apply.
 -}
 type Installation
-    = AddImport Install.Import.Config
+    = AddImport Import.Config
 
 
 {-| Add an import defined by [Install-Import#config].
 -}
-addImport : Install.Import.Config -> Installation
+addImport : Import.Config -> Installation
 addImport =
     AddImport
 
@@ -58,7 +59,7 @@ initContext installations =
                 (\installation context ->
                     case installation of
                         AddImport config ->
-                            { context | importContexts = ( config, Install.Import.init moduleName ) :: context.importContexts }
+                            { context | importContexts = ( config, Install.Internal.Import.init moduleName ) :: context.importContexts }
                 )
                 { importContexts = []
                 }
@@ -72,7 +73,7 @@ moduleDefinitionVisitor node context =
     ( []
     , { importContexts =
             List.map
-                (\( config, importContext ) -> ( config, Install.Import.moduleDefinitionVisitor node importContext ))
+                (\( config, importContext ) -> ( config, Install.Internal.Import.moduleDefinitionVisitor node importContext ))
                 context.importContexts
       }
     )
@@ -83,7 +84,7 @@ importVisitor node context =
     ( []
     , { importContexts =
             List.map
-                (\( config, importContext ) -> ( config, Install.Import.importVisitor config node importContext ))
+                (\( config, importContext ) -> ( config, Install.Internal.Import.importVisitor config node importContext ))
                 context.importContexts
       }
     )
@@ -92,5 +93,5 @@ importVisitor node context =
 finalEvaluation : Context -> List (Rule.Error {})
 finalEvaluation context =
     List.concatMap
-        (\( config, importContext ) -> Install.Import.finalEvaluation config importContext)
+        (\( config, importContext ) -> Install.Internal.Import.finalEvaluation config importContext)
         context.importContexts

--- a/src/Install/Rule.elm
+++ b/src/Install/Rule.elm
@@ -40,9 +40,9 @@ addImport =
 
 {-| Create a rule from a list of transformations.
 -}
-rule : List Installation -> Rule
-rule installations =
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.ClauseInCase" (initContext installations)
+rule : String -> List Installation -> Rule
+rule name installations =
+    Rule.newModuleRuleSchemaUsingContextCreator name (initContext installations)
         |> Rule.withModuleDefinitionVisitor moduleDefinitionVisitor
         |> Rule.withImportVisitor importVisitor
         |> Rule.withFinalModuleEvaluation finalEvaluation

--- a/src/Install/Rule.elm
+++ b/src/Install/Rule.elm
@@ -1,0 +1,76 @@
+module Install.Rule exposing (Installation, rule)
+
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.Module exposing (Module)
+import Elm.Syntax.Node exposing (Node)
+import Install.Import
+import Review.Rule as Rule exposing (Error, Rule)
+
+
+type alias Context =
+    { importContexts : List ( Install.Import.Config, Install.Import.Context )
+    }
+
+
+{-| A transformation to apply.
+-}
+type Installation
+    = AddImport Install.Import.Config
+
+
+{-| Create a rule from a list of transformations.
+-}
+rule : List Installation -> Rule
+rule installations =
+    Rule.newModuleRuleSchemaUsingContextCreator "Install.ClauseInCase" (initContext installations)
+        |> Rule.withModuleDefinitionVisitor moduleDefinitionVisitor
+        |> Rule.withImportVisitor importVisitor
+        |> Rule.withFinalModuleEvaluation finalEvaluation
+        |> Rule.providesFixesForModuleRule
+        |> Rule.fromModuleRuleSchema
+
+
+initContext : List Installation -> Rule.ContextCreator () Context
+initContext installations =
+    Rule.initContextCreator
+        (\moduleName () ->
+            List.foldl
+                (\installation context ->
+                    case installation of
+                        AddImport config ->
+                            { context | importContexts = ( config, Install.Import.init moduleName ) :: context.importContexts }
+                )
+                { importContexts = []
+                }
+                installations
+        )
+        |> Rule.withModuleName
+
+
+moduleDefinitionVisitor : Node Module -> Context -> ( List (Error {}), Context )
+moduleDefinitionVisitor node context =
+    ( []
+    , { importContexts =
+            List.map
+                (\( config, importContext ) -> ( config, Install.Import.moduleDefinitionVisitor node importContext ))
+                context.importContexts
+      }
+    )
+
+
+importVisitor : Node Import -> Context -> ( List (Error {}), Context )
+importVisitor node context =
+    ( []
+    , { importContexts =
+            List.map
+                (\( config, importContext ) -> ( config, Install.Import.importVisitor config node importContext ))
+                context.importContexts
+      }
+    )
+
+
+finalEvaluation : Context -> List (Rule.Error {})
+finalEvaluation context =
+    List.concatMap
+        (\( config, importContext ) -> Install.Import.finalEvaluation config importContext)
+        context.importContexts

--- a/src/Install/Rule.elm
+++ b/src/Install/Rule.elm
@@ -60,7 +60,7 @@ initContext installations =
                     case installation of
                         AddImport ((Install.Internal.Import.Config { hostModuleName }) as config) ->
                             if moduleName == hostModuleName then
-                                { context | importContexts = ( config, Install.Internal.Import.init moduleName ) :: context.importContexts }
+                                { context | importContexts = ( config, Install.Internal.Import.init ) :: context.importContexts }
 
                             else
                                 context

--- a/src/Install/Subscription.elm
+++ b/src/Install/Subscription.elm
@@ -1,19 +1,18 @@
-module Install.Subscription exposing (makeRule)
+module Install.Subscription exposing (config, Config)
 
 {-| Use this rule to add to the list of subscriptions.
 
-@docs makeRule
+@docs config, Config
 
 -}
 
-import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Expression exposing (Expression(..))
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range exposing (Location, Range)
-import Install.Library
-import Review.Fix as Fix
-import Review.Rule as Rule exposing (Error, Rule)
+import Install.Internal.Subscription as Internal
+
+
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
 
 
 {-| Suppose that you have the following code in your `Backend.elm` file:
@@ -23,7 +22,8 @@ import Review.Rule as Rule exposing (Error, Rule)
 
 and that you want to add `baz` to the list. To do this, say
 
-    Install.Subscription.makeRule "Backend" [ "baz" ]
+    Install.Subscription.config "Backend" [ "baz" ]
+        |> Install.subscription
 
 The result is
 
@@ -31,110 +31,9 @@ The result is
         Sub.batch [ foo, bar, baz ]
 
 -}
-makeRule : String -> List String -> Rule
-makeRule moduleName subscriptions =
-    let
-        --visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor =
-            declarationVisitor moduleName subscriptions
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.Subscription" contextCreator
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-type alias Context =
-    { moduleName : ModuleName
-    }
-
-
-contextCreator : Rule.ContextCreator () Context
-contextCreator =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-
-            -- ...other fields
-            }
-        )
-        |> Rule.withModuleName
-
-
-declarationVisitor : String -> List String -> Node Declaration -> Context -> ( List (Rule.Error {}), Context )
-declarationVisitor moduleName items (Node _ declaration) context =
-    if Install.Library.isInCorrectModule moduleName context then
-        case declaration of
-            FunctionDeclaration function ->
-                let
-                    implementation =
-                        Node.value function.declaration
-
-                    name : String
-                    name =
-                        Node.value implementation.name
-                in
-                if name /= "subscriptions" then
-                    ( [], context )
-
-                else
-                    case Node.value implementation.expression of
-                        Application ((Node _ (FunctionOrValue [ "Sub" ] "batch")) :: rest) ->
-                            let
-                                listElements =
-                                    rest
-                                        |> List.head
-                                        |> Maybe.map Node.value
-                                        |> (\expression ->
-                                                case expression of
-                                                    Just (ListExpr exprs) ->
-                                                        exprs
-
-                                                    _ ->
-                                                        []
-                                           )
-
-                                isAlreadyImplemented =
-                                    Install.Library.areItemsInList items listElements
-                            in
-                            if isAlreadyImplemented then
-                                ( [], context )
-
-                            else
-                                let
-                                    expr =
-                                        implementation.expression
-
-                                    endOfRange =
-                                        (Node.range expr).end
-
-                                    nameRange =
-                                        Node.range implementation.name
-
-                                    replacementCode =
-                                        items
-                                            |> List.map (\item -> ", " ++ item)
-                                            |> String.concat
-                                in
-                                ( [ errorWithFix replacementCode nameRange endOfRange rest ], context )
-
-                        _ ->
-                            ( [], context )
-
-            _ ->
-                ( [], context )
-
-    else
-        ( [], context )
-
-
-errorWithFix : String -> Range -> Location -> List (Node Expression) -> Error {}
-errorWithFix replacementCode range endRange subList =
-    Rule.errorWithFix
-        { message = "Add to subscriptions: " ++ replacementCode
-        , details =
-            [ ""
-            ]
+config : String -> List String -> Config
+config hostModuleName subscriptions =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , subscriptions = subscriptions
         }
-        range
-        [ Fix.insertAt { endRange | column = endRange.column - 2 } replacementCode ]

--- a/src/Install/Type.elm
+++ b/src/Install/Type.elm
@@ -1,104 +1,42 @@
-module Install.Type exposing (makeRule)
+module Install.Type exposing (config, Config)
 
 {-| `Install.Type` provides a rule that checks if a type is present
 in the given module and if not, it adds it right after the imports.
 
 For example, the rule
 
-          Install.Type.makeRule "Frontend" "Magic" [ "Inactive", "Wizard String", "Spell String Int"]
+    Install.Type.config "Frontend" "Magic" [ "Inactive", "Wizard String", "Spell String Int" ]
+        |> Install.addType
 
 results in insertion the text below in the module "Frontend":
 
-          type Magic
-              = Inactive
-              | Wizard String
-              | Spell String Int
+    type Magic
+        = Inactive
+        | Wizard String
+        | Spell String Int
 
-@docs makeRule
+@docs config, Config
 
 -}
 
-import Elm.Syntax.Declaration as Declaration exposing (Declaration)
-import Elm.Syntax.Import exposing (Import)
-import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node)
-import Elm.Syntax.Range as Range exposing (Range)
-import Install.Library
-import List.Extra
-import Review.Fix as Fix
-import Review.Rule as Rule exposing (Error, Rule)
+import Install.Internal.Type as Internal
+
+
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
 
 
 {-| Rule to add a type to a module if it is not present
 -}
-makeRule : String -> String -> List String -> Rule
-makeRule hostModuleName typeName_ variants_ =
-    let
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor =
-            declarationVisitor hostModuleName typeName_
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.Type" initialContext
-        |> Rule.withImportVisitor importVisitor
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.withFinalModuleEvaluation (finalEvaluation hostModuleName typeName_ variants_)
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
-
-
-importVisitor : Node Import -> Context -> ( List (Error {}), Context )
-importVisitor node context =
-    ( [], { context | lastNodeRange = Node.range node } )
-
-
-finalEvaluation : String -> String -> List String -> Context -> List (Rule.Error {})
-finalEvaluation hostModuleName typeName_ variants_ context =
-    if context.typeIsPresent == False && String.split "." hostModuleName == context.moduleName then
-        fixError typeName_ variants_ context
-
-    else
-        []
-
-
-fixError : String -> List String -> Context -> List (Error {})
-fixError typeName_ variants_ context =
-    let
-        codeToAdd =
-            case List.Extra.uncons variants_ of
-                Nothing ->
-                    ""
-
-                Just ( head, tail ) ->
-                    "\n"
-                        ++ (String.join "  " [ "type", typeName_, "=" ]
-                                :: ("    " ++ head)
-                                :: List.map (\s -> "  | " ++ s) tail
-                                |> String.join "\n"
-                           )
-    in
-    [ Rule.errorWithFix
-        { message = "add type: \"" ++ typeName_, details = [ "" ] }
-        context.lastNodeRange
-        [ Fix.insertAt { row = context.lastNodeRange.end.row + 2, column = 0 } codeToAdd ]
-    ]
-
-
-declarationVisitor : String -> String -> Node Declaration -> Context -> ( List (Error {}), Context )
-declarationVisitor moduleName_ typeName_ node context =
-    case Node.value node of
-        Declaration.CustomTypeDeclaration type_ ->
-            let
-                isInCorrectModule =
-                    Install.Library.isInCorrectModule moduleName_ context
-            in
-            if isInCorrectModule && Node.value type_.name == typeName_ then
-                ( [], { context | typeIsPresent = True, lastNodeRange = Node.range node } )
-
-            else
-                ( [], { context | lastNodeRange = Node.range node } )
-
-        _ ->
-            ( [], context )
+config : String -> String -> List String -> Config
+config hostModuleName typeName variants =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , typeName = typeName
+        , variants = variants
+        }
 
 
 
@@ -106,17 +44,3 @@ declarationVisitor moduleName_ typeName_ node context =
 --moduleDefinitionVisitor def context =
 --    -- visit the module definition to set the module definition as the lastNodeRange in case the module has no types yet TODO: ??
 --    ( [], { context | lastNodeRange = Node.range def } )
-
-
-type alias Context =
-    { moduleName : ModuleName
-    , typeIsPresent : Bool
-    , lastNodeRange : Range
-    }
-
-
-initialContext : Rule.ContextCreator () Context
-initialContext =
-    Rule.initContextCreator
-        (\moduleName () -> { moduleName = moduleName, typeIsPresent = False, lastNodeRange = Range.empty })
-        |> Rule.withModuleName

--- a/src/Install/TypeVariant.elm
+++ b/src/Install/TypeVariant.elm
@@ -105,7 +105,7 @@ declarationVisitor moduleName typeName variantList node context =
                     "\n    | " ++ variantString
 
                 variantNames =
-                    List.map variantName variantList |> List.filterMap identity
+                    List.filterMap variantName variantList
 
                 shouldFix : Node Declaration -> Context -> Bool
                 shouldFix node_ context_ =
@@ -126,7 +126,7 @@ declarationVisitor moduleName typeName variantList node context =
             if isInCorrectModule && Node.value type_.name == typeName && shouldFix node context then
                 let
                     variantCode =
-                        List.map variantCodeItem variantList |> String.join ""
+                        List.map variantCodeItem variantList |> String.concat
                 in
                 ( [ errorWithFix typeName variantNames variantCode node (Just <| Node.range node) ]
                 , context

--- a/src/Install/TypeVariant.elm
+++ b/src/Install/TypeVariant.elm
@@ -1,10 +1,14 @@
-module Install.TypeVariant exposing (makeRule)
+module Install.TypeVariant exposing (config, Config)
 
 {-| Add a variant to a given type in a given module. As in
 the `ReviewConfig` item below, you specify the module name, the type
 name, and the type of the new variant.
 
-    Install.TypeVariant.makeRule "Types" "ToBackend" [ "ResetCounter" "SetCounter Int" ]
+    Install.TypeVariant.config
+        "Types"
+        "ToBackend"
+        [ "ResetCounter" "SetCounter Int" ]
+        |> Install.addTypeVariant
 
 Then you will have
 
@@ -16,7 +20,7 @@ Then you will have
 
 where the last two variants are the ones added.
 
-@docs makeRule
+@docs config, Config
 
 -}
 
@@ -24,6 +28,7 @@ import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range exposing (Range)
+import Install.Internal.TypeVariant as Internal
 import Install.Library
 import Review.Fix as Fix exposing (Fix)
 import Review.Rule as Rule exposing (Error, Rule)
@@ -31,22 +36,28 @@ import Set exposing (Set)
 import Set.Extra
 
 
+{-| Configuration for rule.
+-}
+type alias Config =
+    Internal.Config
+
+
 {-| Create a rule that adds variants to a type in a specified module:
 
-    Install.TypeVariant.makeRule "Types" "ToBackend" [ "ResetCounter", "SetCounter: Int" ]
+    Install.TypeVariant.config
+        "Types"
+        "ToBackend"
+        [ "ResetCounter", "SetCounter: Int" ]
+        |> Install.addTypeVariant
 
 -}
-makeRule : String -> String -> List String -> Rule
-makeRule moduleName typeName_ variantList =
-    let
-        visitor : Node Declaration -> Context -> ( List (Error {}), Context )
-        visitor =
-            declarationVisitor moduleName typeName_ variantList
-    in
-    Rule.newModuleRuleSchemaUsingContextCreator "Install.TypeVariant" contextCreator
-        |> Rule.withDeclarationEnterVisitor visitor
-        |> Rule.providesFixesForModuleRule
-        |> Rule.fromModuleRuleSchema
+config : String -> String -> List String -> Config
+config hostModuleName typeName variants =
+    Internal.Config
+        { hostModuleName = String.split "." hostModuleName
+        , typeName = typeName
+        , variants = variants
+        }
 
 
 type alias Context =

--- a/tests/Install/ClauseInCaseTest.elm
+++ b/tests/Install/ClauseInCaseTest.elm
@@ -1,6 +1,7 @@
 module Install.ClauseInCaseTest exposing (all)
 
-import Install.ClauseInCase exposing (config, makeRule)
+import Install
+import Install.ClauseInCase exposing (config)
 import Run
 import Test exposing (Test, describe)
 
@@ -8,14 +9,14 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.ClauseInCase1"
-        [ Run.expectNoErrorsTest "should not report an error when REPLACEME" src1 rule1
+        [ Run.expectNoErrorsTest_ "should not report an error when REPLACEME" src1 rule1
         , Run.expectErrorsTest "should report an error when REPLACEME" src1 rule1
         ]
 
 
 rule1 =
     config "REPLACEME" "REPLACEME" "REPLACEME" "REPLACEME"
-        |> makeRule
+        |> Install.insertClauseInCase
 
 
 src1 =

--- a/tests/Install/ClauseInCaseTest2.elm
+++ b/tests/Install/ClauseInCaseTest2.elm
@@ -1,26 +1,26 @@
 module Install.ClauseInCaseTest2 exposing (all)
 
+import Install exposing (Installation)
 import Install.ClauseInCase
-import Review.Rule exposing (Rule)
-import Run exposing (TestData)
+import Run exposing (TestData_)
 import Test exposing (Test, describe)
 
 
 all : Test
 all =
     describe "Install.ClauseInCase"
-        [ Run.testFix test1a
-        , Run.testFix test1b
-        , Run.testFix test1c
-        , Run.testFix test2
-        , Run.testFix test3
-        , Run.testFix test4
-        , Run.testFix test5
-        , Run.testFix test6
-        , Run.testFix test7
-        , Run.testFix test8
-        , Run.testFix test9
-        , Run.testFix test10
+        [ Run.testFix_ test1a
+        , Run.testFix_ test1b
+        , Run.testFix_ test1c
+        , Run.testFix_ test2
+        , Run.testFix_ test3
+        , Run.testFix_ test4
+        , Run.testFix_ test5
+        , Run.testFix_ test6
+        , Run.testFix_ test7
+        , Run.testFix_ test8
+        , Run.testFix_ test9
+        , Run.testFix_ test10
         ]
 
 
@@ -28,57 +28,57 @@ all =
 -- TEST 1
 
 
-test1a : TestData
+test1a : TestData_
 test1a =
     { description = "Test 1a, simple makeRule: should report an error and fix it"
     , src = src1
-    , rule = rule1a
+    , installation = rule1a
     , under = under1
     , fixed = fixed1
     , message = "Add handler for ResetCounter"
     }
 
 
-test1b : TestData
+test1b : TestData_
 test1b =
     { description = "Test 1b, withInsertAfter CounterIncremented: should report an error and fix it"
     , src = src1
-    , rule = rule1b
+    , installation = rule1b
     , under = under1
     , fixed = fixed1
     , message = "Add handler for ResetCounter"
     }
 
 
-test1c : TestData
+test1c : TestData_
 test1c =
     { description = "Test 1c, withInsertAtBeginning: should report an error and fix it"
     , src = src1
-    , rule = rule1c
+    , installation = rule1c
     , under = under1
     , fixed = fixed1c
     , message = "Add handler for ResetCounter"
     }
 
 
-rule1a : Rule
+rule1a : Installation
 rule1a =
     Install.ClauseInCase.config "Backend" "updateFromFrontend" "ResetCounter" "( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
-rule1b : Rule
+rule1b : Installation
 rule1b =
     Install.ClauseInCase.config "Backend" "updateFromFrontend" "ResetCounter" "( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )"
         |> Install.ClauseInCase.withInsertAfter "CounterIncremented"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
-rule1c : Rule
+rule1c : Installation
 rule1c =
     Install.ClauseInCase.config "Backend" "updateFromFrontend" "ResetCounter" "( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )"
         |> Install.ClauseInCase.withInsertAtBeginning
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 src1 : String
@@ -154,22 +154,22 @@ under1 =
 -- TEST 2
 
 
-test2 : TestData
+test2 : TestData_
 test2 =
     { description = "Test 2 (Reset, Frontend.update): should report an error and fix it"
     , src = src2
-    , rule = rule2
+    , installation = rule2
     , under = under2
     , fixed = fixed2
     , message = "Add handler for Reset"
     }
 
 
-rule2 : Rule
+rule2 : Installation
 rule2 =
     Install.ClauseInCase.config "Frontend" "update" "Reset" "( { model | counter = 0 }, sendToBackend CounterReset )"
         |> Install.ClauseInCase.withInsertAfter "Increment"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 src2 : String
@@ -227,11 +227,11 @@ under2 =
 -- TEST 3
 
 
-test3 : TestData
+test3 : TestData_
 test3 =
     { description = "Test 2: should escape string pattern when is a case of string patterns"
     , src = src3
-    , rule = rule3
+    , installation = rule3
     , under = under3
     , fixed = fixed3
     , message = "Add handler for Aspasia"
@@ -263,11 +263,11 @@ stringToPhilosopher str =
                 Nothing"""
 
 
-rule3 : Rule
+rule3 : Installation
 rule3 =
     Install.ClauseInCase.config "Philosopher" "stringToPhilosopher" "Aspasia" "Just Aspasia"
         |> Install.ClauseInCase.withInsertAfter "Aristotle"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under3 : String
@@ -317,11 +317,11 @@ stringToPhilosopher str =
 -- TEST 4
 
 
-test4 : TestData
+test4 : TestData_
 test4 =
     { description = "Test 4: should add clause when case is inside let in expression"
     , src = src4
-    , rule = rule4
+    , installation = rule4
     , under = under4
     , fixed = fixed4
     , message = "Add handler for _"
@@ -342,10 +342,10 @@ isStringPattern nodePattern =
 """
 
 
-rule4 : Rule
+rule4 : Installation
 rule4 =
     Install.ClauseInCase.config "Elm.Syntax.Pattern2" "isStringPattern" "_" "False"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under4 : String
@@ -374,11 +374,11 @@ isStringPattern nodePattern =
 -- TEST 5
 
 
-test5 : TestData
+test5 : TestData_
 test5 =
     { description = "Test 5: should add clause when case is inside tupled expression"
     , src = src5
-    , rule = rule5
+    , installation = rule5
     , under = under5
     , fixed = fixed5
     , message = "Add handler for empty error string"
@@ -399,12 +399,12 @@ errorFix context node maybeError =
     """
 
 
-rule5 : Rule
+rule5 : Installation
 rule5 =
     Install.ClauseInCase.config "SomeElmReviewRule" "errorFix" "Just \"\"" "[]"
         |> Install.ClauseInCase.withInsertAtBeginning
         |> Install.ClauseInCase.withCustomErrorMessage "Add handler for empty error string" [ "" ]
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under5 : String
@@ -436,11 +436,11 @@ errorFix context node maybeError =
 -- TEST 6
 
 
-test6 : TestData
+test6 : TestData_
 test6 =
     { description = "Test 6: should add clause when case is inside parenthesized expression"
     , src = src6
-    , rule = rule6
+    , installation = rule6
     , under = under6
     , fixed = fixed6
     , message = "Add handler for Sun"
@@ -473,11 +473,11 @@ getShiftFormFromWeekday weekday =
     )"""
 
 
-rule6 : Rule
+rule6 : Installation
 rule6 =
     Install.ClauseInCase.config "WeekShiftForm" "getShiftFormFromWeekday" "Sun" ".sunday"
         |> Install.ClauseInCase.withInsertAfter "Sat"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under6 : String
@@ -534,11 +534,11 @@ getShiftFormFromWeekday weekday =
 -- TEST 7 - IfBlock test
 
 
-test7 : TestData
+test7 : TestData_
 test7 =
     { description = "Test 7: should add clause when case is inside if block"
     , src = src7
-    , rule = rule7
+    , installation = rule7
     , under = under7
     , fixed = fixed7
     , message = "Add handler for Just []"
@@ -562,11 +562,11 @@ someFunction condition maybeData =
         Result.Err "Condition not satisfied" """
 
 
-rule7 : Rule
+rule7 : Installation
 rule7 =
     Install.ClauseInCase.config "Backend" "someFunction" "Just []" "Result.Err \"Empty data\""
         |> Install.ClauseInCase.withInsertAtBeginning
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under7 : String
@@ -602,11 +602,11 @@ someFunction condition maybeData =
 -- TEST 8 - Application test
 
 
-test8 : TestData
+test8 : TestData_
 test8 =
     { description = "Test 8: should add clause when case is inside application"
     , src = src8
-    , rule = rule8
+    , installation = rule8
     , under = under8
     , fixed = fixed8
     , message = "Add handler for Sun"
@@ -640,11 +640,11 @@ getShiftFormFromWeekday weekday weekShiftForm =
         weekShiftForm"""
 
 
-rule8 : Rule
+rule8 : Installation
 rule8 =
     Install.ClauseInCase.config "WeekShiftForm" "getShiftFormFromWeekday" "Sun" ".sunday"
         |> Install.ClauseInCase.withInsertAfter "Sat"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under8 : String
@@ -702,11 +702,11 @@ getShiftFormFromWeekday weekday weekShiftForm =
 -- TEST 9 - OperatorApplication and LambdaExpression test
 
 
-test9 : TestData
+test9 : TestData_
 test9 =
     { description = "Test 9: should add clause when case is inside operator application and Lambda Expression"
     , src = src9
-    , rule = rule9
+    , installation = rule9
     , under = under9
     , fixed = fixed9
     , message = "Add handler for Just []"
@@ -735,11 +735,11 @@ decodeFieldErrors =
             )"""
 
 
-rule9 : Rule
+rule9 : Installation
 rule9 =
     Install.ClauseInCase.config "Errors" "decodeFieldErrors" "Just []" "Dict.singleton \"base\" []"
         |> Install.ClauseInCase.withInsertAtBeginning
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under9 : String
@@ -784,11 +784,11 @@ decodeFieldErrors =
 -- Test 10: ListExpression test
 
 
-test10 : TestData
+test10 : TestData_
 test10 =
     { description = "Test 10: should add clause when case is inside list expression"
     , src = src10
-    , rule = rule10
+    , installation = rule10
     , under = under10
     , fixed = fixed10
     , message = "Add handler for ModalConfirm"
@@ -813,10 +813,10 @@ viewModal modal =
         ]"""
 
 
-rule10 : Rule
+rule10 : Installation
 rule10 =
     Install.ClauseInCase.config "Modal" "viewModal" "ModalConfirm" "div [class \"modal-confirm\"] []"
-        |> Install.ClauseInCase.makeRule
+        |> Install.insertClauseInCase
 
 
 under10 : String

--- a/tests/Install/ClauseInCaseTest2.elm
+++ b/tests/Install/ClauseInCaseTest2.elm
@@ -2,7 +2,7 @@ module Install.ClauseInCaseTest2 exposing (all)
 
 import Install.ClauseInCase
 import Review.Rule exposing (Rule)
-import Run
+import Run exposing (TestData)
 import Test exposing (Test, describe)
 
 
@@ -28,7 +28,7 @@ all =
 -- TEST 1
 
 
-test1a : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1a : TestData
 test1a =
     { description = "Test 1a, simple makeRule: should report an error and fix it"
     , src = src1
@@ -39,7 +39,7 @@ test1a =
     }
 
 
-test1b : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1b : TestData
 test1b =
     { description = "Test 1b, withInsertAfter CounterIncremented: should report an error and fix it"
     , src = src1
@@ -50,7 +50,7 @@ test1b =
     }
 
 
-test1c : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1c : TestData
 test1c =
     { description = "Test 1c, withInsertAtBeginning: should report an error and fix it"
     , src = src1
@@ -154,7 +154,7 @@ under1 =
 -- TEST 2
 
 
-test2 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test2 : TestData
 test2 =
     { description = "Test 2 (Reset, Frontend.update): should report an error and fix it"
     , src = src2
@@ -227,7 +227,7 @@ under2 =
 -- TEST 3
 
 
-test3 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test3 : TestData
 test3 =
     { description = "Test 2: should escape string pattern when is a case of string patterns"
     , src = src3
@@ -317,7 +317,7 @@ stringToPhilosopher str =
 -- TEST 4
 
 
-test4 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4 : TestData
 test4 =
     { description = "Test 4: should add clause when case is inside let in expression"
     , src = src4
@@ -374,7 +374,7 @@ isStringPattern nodePattern =
 -- TEST 5
 
 
-test5 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test5 : TestData
 test5 =
     { description = "Test 5: should add clause when case is inside tupled expression"
     , src = src5
@@ -436,7 +436,7 @@ errorFix context node maybeError =
 -- TEST 6
 
 
-test6 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test6 : TestData
 test6 =
     { description = "Test 6: should add clause when case is inside parenthesized expression"
     , src = src6
@@ -534,7 +534,7 @@ getShiftFormFromWeekday weekday =
 -- TEST 7 - IfBlock test
 
 
-test7 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test7 : TestData
 test7 =
     { description = "Test 7: should add clause when case is inside if block"
     , src = src7
@@ -602,7 +602,7 @@ someFunction condition maybeData =
 -- TEST 8 - Application test
 
 
-test8 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test8 : TestData
 test8 =
     { description = "Test 8: should add clause when case is inside application"
     , src = src8
@@ -702,7 +702,7 @@ getShiftFormFromWeekday weekday weekShiftForm =
 -- TEST 9 - OperatorApplication and LambdaExpression test
 
 
-test9 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test9 : TestData
 test9 =
     { description = "Test 9: should add clause when case is inside operator application and Lambda Expression"
     , src = src9
@@ -784,7 +784,7 @@ decodeFieldErrors =
 -- Test 10: ListExpression test
 
 
-test10 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test10 : TestData
 test10 =
     { description = "Test 10: should add clause when case is inside list expression"
     , src = src10

--- a/tests/Install/ElementToListTest.elm
+++ b/tests/Install/ElementToListTest.elm
@@ -1,7 +1,7 @@
 module Install.ElementToListTest exposing (all)
 
+import Install
 import Install.ElementToList as ElementToList
-import Install.Rule
 import Run
 import Test exposing (Test, describe)
 
@@ -62,7 +62,7 @@ contributors =
 
 rule1 =
     ElementToList.add "Contributors" "contributors" [ "Matt" ]
-        |> Install.Rule.addElementToList
+        |> Install.addElementToList
 
 
 under1 =
@@ -115,7 +115,7 @@ rule2 =
         "Contributors"
         "contributors"
         [ "Matt", "Laozi" ]
-        |> Install.Rule.addElementToList
+        |> Install.addElementToList
 
 
 under2 =
@@ -168,7 +168,7 @@ rule4 =
         "Routes"
         "routesAndNames"
         [ "(Quotes, \"quotes\")" ]
-        |> Install.Rule.addElementToList
+        |> Install.addElementToList
 
 
 under4 =

--- a/tests/Install/ElementToListTest.elm
+++ b/tests/Install/ElementToListTest.elm
@@ -1,6 +1,7 @@
 module Install.ElementToListTest exposing (all)
 
-import Install.ElementToList exposing (makeRule)
+import Install.ElementToList as ElementToList
+import Install.Rule
 import Run
 import Test exposing (Test, describe)
 
@@ -8,10 +9,10 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.ElementToList"
-        [ Run.testFix test1
-        , Run.expectNoErrorsTest "should not report error when the field already exists" src0 rule1
-        , Run.testFix test2
-        , Run.testFix test4
+        [ Run.testFix_ test1
+        , Run.expectNoErrorsTest_ "should not report error when the field already exists" src0 rule1
+        , Run.testFix_ test2
+        , Run.testFix_ test4
         ]
 
 
@@ -39,7 +40,7 @@ contributors =
 test1 =
     { description = "should add element to the list"
     , src = src1
-    , rule = rule1
+    , installation = rule1
     , under = under1
     , fixed = fixed1
     , message = "Add 1 element to the list"
@@ -60,7 +61,8 @@ contributors =
 
 
 rule1 =
-    makeRule "Contributors" "contributors" [ "Matt" ]
+    ElementToList.add "Contributors" "contributors" [ "Matt" ]
+        |> Install.Rule.addElementToList
 
 
 under1 =
@@ -87,7 +89,7 @@ contributors =
 test2 =
     { description = "should add multiple elements to the list"
     , src = src2
-    , rule = rule2
+    , installation = rule2
     , under = under2
     , fixed = fixed2
     , message = "Add 2 elements to the list"
@@ -109,7 +111,11 @@ contributors =
 
 
 rule2 =
-    makeRule "Contributors" "contributors" [ "Matt", "Laozi" ]
+    ElementToList.add
+        "Contributors"
+        "contributors"
+        [ "Matt", "Laozi" ]
+        |> Install.Rule.addElementToList
 
 
 under2 =
@@ -137,7 +143,7 @@ contributors =
 test4 =
     { description = "should add an element to a list of tuples in project"
     , src = src4
-    , rule = rule4
+    , installation = rule4
     , under = under4
     , fixed = fixed4
     , message = "Add 2 elements to the list"
@@ -158,7 +164,11 @@ routesAndNames =
 
 
 rule4 =
-    makeRule "Routes" "routesAndNames" [ "(Quotes, \"quotes\")" ]
+    ElementToList.add
+        "Routes"
+        "routesAndNames"
+        [ "(Quotes, \"quotes\")" ]
+        |> Install.Rule.addElementToList
 
 
 under4 =

--- a/tests/Install/FieldInTypeAliasTest.elm
+++ b/tests/Install/FieldInTypeAliasTest.elm
@@ -1,5 +1,6 @@
 module Install.FieldInTypeAliasTest exposing (..)
 
+import Install
 import Install.FieldInTypeAlias
 import Run
 import Test exposing (Test, describe)
@@ -8,10 +9,10 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.FieldInTypeAlias"
-        [ Run.expectNoErrorsTest test1.description test1.src test1.rule
-        , Run.testFix test2
-        , Run.testFix test3
-        , Run.testFix test4
+        [ Run.expectNoErrorsTest_ test1.description test1.src test1.installation
+        , Run.testFix_ test2
+        , Run.testFix_ test3
+        , Run.testFix_ test4
         ]
 
 
@@ -23,7 +24,9 @@ type alias Client =
     , age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" [ "name : String" ]
+    , installation =
+        Install.FieldInTypeAlias.config "Client" "Client" [ "name : String" ]
+            |> Install.insertFieldInTypeAlias
     }
 
 
@@ -34,7 +37,9 @@ type alias Client =
     { age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" [ "name : String" ]
+    , installation =
+        Install.FieldInTypeAlias.config "Client" "Client" [ "name : String" ]
+            |> Install.insertFieldInTypeAlias
     , under = """type alias Client =
     { age : Int
     }"""
@@ -55,7 +60,9 @@ type alias Client =
     { age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Data.Client" "Client" [ "name : String" ]
+    , installation =
+        Install.FieldInTypeAlias.config "Data.Client" "Client" [ "name : String" ]
+            |> Install.insertFieldInTypeAlias
     , under = """type alias Client =
     { age : Int
     }"""
@@ -80,7 +87,9 @@ type alias Client =
     { age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" [ "name : String", "email : String", "age : Int", "lastName : String", "favoriteColor : String" ]
+    , installation =
+        Install.FieldInTypeAlias.config "Client" "Client" [ "name : String", "email : String", "age : Int", "lastName : String", "favoriteColor : String" ]
+            |> Install.insertFieldInTypeAlias
     , under = """type alias Client =
     { age : Int
     }"""

--- a/tests/Install/FunctionTest.elm
+++ b/tests/Install/FunctionTest.elm
@@ -1,5 +1,6 @@
 module Install.FunctionTest exposing (all)
 
+import Install exposing (Installation)
 import Install.Function.InsertFunction as InsertFunction
 import Install.Function.ReplaceFunction as ReplaceFunction
 import Review.Rule exposing (Rule)
@@ -12,13 +13,13 @@ all =
     describe "Install.Function"
         [ Run.testFix test1
         , Run.testFix test1b
-        , Run.testFix test2
-        , Run.testFix test2a
-        , Run.testFix test3
-        , Run.testFix test4
-        , Run.testFix test4a
-        , Run.testFix test4b
-        , Run.testFix test4c
+        , Run.testFix_ test2
+        , Run.testFix_ test2a
+        , Run.testFix_ test3
+        , Run.testFix_ test4
+        , Run.testFix_ test4a
+        , Run.testFix_ test4b
+        , Run.testFix_ test4c
         ]
 
 
@@ -197,25 +198,25 @@ makeLinks =
 -- TEST 2 - Should add a new function
 
 
-test2 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test2 : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test2 =
     { description = "Test 2, add a new function"
     , src = src1
-    , rule = rule2
+    , installation = rule2
     , under = under2
     , fixed = fixed2
     , message = "Add function \"newFunction\""
     }
 
 
-rule2 : Rule
+rule2 : Installation
 rule2 =
-    InsertFunction.config
+    InsertFunction.insert
         "Frontend"
         "newFunction"
         """newFunction model =
     Html.text "This is a test\""""
-        |> InsertFunction.makeRule
+        |> Install.insertFunction
 
 
 under2 : String
@@ -250,24 +251,24 @@ newFunction model =
 -- TEST 2A - should add new function with unformatted code
 
 
-test2a : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test2a : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test2a =
     { description = "Test 2a, add a new function with unformatted code"
     , src = src1
-    , rule = rule2a
+    , installation = rule2a
     , under = under2
     , fixed = fixed2a
     , message = "Add function \"makeLinks\""
     }
 
 
-rule2a : Rule
+rule2a : Installation
 rule2a =
-    InsertFunction.config
+    InsertFunction.insert
         "Frontend"
         "makeLinks"
         makeLinks
-        |> InsertFunction.makeRule
+        |> Install.insertFunction
 
 
 fixed2a : String
@@ -302,11 +303,11 @@ makeLinks model route =
 -- TEST 3 - Should add a new function when there is no function in the module
 
 
-test3 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test3 : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test3 =
     { description = "Test 3, add a new function when there is no function in the module"
     , src = src3
-    , rule = rule3
+    , installation = rule3
     , under = under3
     , fixed = fixed3
     , message = "Add function \"newFunction\""
@@ -325,14 +326,14 @@ type alias Model =
 """
 
 
-rule3 : Rule
+rule3 : Installation
 rule3 =
-    InsertFunction.config
+    InsertFunction.insert
         "Frontend"
         "newFunction"
         """newFunction model =
     Html.text "This is a test\""""
-        |> InsertFunction.makeRule
+        |> Install.insertFunction
 
 
 under3 : String
@@ -358,26 +359,26 @@ newFunction model =
 -- TEST 4 - Should add a new function after a specific function
 
 
-test4 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4 : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test4 =
     { description = "Test 4, add a new function after a specific function"
     , src = src1
-    , rule = rule4
+    , installation = rule4
     , under = under4
     , fixed = fixed4
     , message = "Add function \"newFunction\""
     }
 
 
-rule4 : Rule
+rule4 : Installation
 rule4 =
-    InsertFunction.config
+    InsertFunction.insert
         "Frontend"
         "newFunction"
         """newFunction model =
     Html.text "This is a test\""""
         |> InsertFunction.withInsertAfter "view"
-        |> InsertFunction.makeRule
+        |> Install.insertFunction
 
 
 under4 : String
@@ -405,26 +406,26 @@ update msg model =
             model"""
 
 
-test4a : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4a : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test4a =
     { description = "Test 4a, add a new function after a specific type"
     , src = src1
-    , rule = rule4a
+    , installation = rule4a
     , under = under4a
     , fixed = fixed4a
     , message = "Add function \"newFunction\""
     }
 
 
-rule4a : Rule
+rule4a : Installation
 rule4a =
-    InsertFunction.config
+    InsertFunction.insert
         "Frontend"
         "newFunction"
         """newFunction model =
     Html.text "This is a test\""""
         |> InsertFunction.withInsertAfter "Model"
-        |> InsertFunction.makeRule
+        |> Install.insertFunction
 
 
 under4a : String
@@ -451,26 +452,26 @@ update msg model =
             model"""
 
 
-test4b : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4b : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test4b =
     { description = "Test 4b, add a new function after a specific type alias"
     , src = src3
-    , rule = rule4b
+    , installation = rule4b
     , under = under4b
     , fixed = fixed4b
     , message = "Add function \"newFunction\""
     }
 
 
-rule4b : Rule
+rule4b : Installation
 rule4b =
-    InsertFunction.config
+    InsertFunction.insert
         "Frontend"
         "newFunction"
         """newFunction model =
     Html.text "This is a test\""""
         |> InsertFunction.withInsertAfter "Model"
-        |> InsertFunction.makeRule
+        |> Install.insertFunction
 
 
 under4b : String
@@ -492,11 +493,11 @@ newFunction model =
     Html.text "This is a test\""""
 
 
-test4c : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4c : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test4c =
     { description = "Test 4c, add a new function after a specific type alias"
     , src = src3
-    , rule = rule4b
+    , installation = rule4b
     , under = under4b
     , fixed = fixed4b
     , message = "Add function \"newFunction\""

--- a/tests/Install/FunctionTest.elm
+++ b/tests/Install/FunctionTest.elm
@@ -3,7 +3,6 @@ module Install.FunctionTest exposing (all)
 import Install exposing (Installation)
 import Install.Function.InsertFunction as InsertFunction
 import Install.Function.ReplaceFunction as ReplaceFunction
-import Review.Rule exposing (Rule)
 import Run
 import Test exposing (Test, describe)
 
@@ -11,8 +10,8 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.Function"
-        [ Run.testFix test1
-        , Run.testFix test1b
+        [ Run.testFix_ test1
+        , Run.testFix_ test1b
         , Run.testFix_ test2
         , Run.testFix_ test2a
         , Run.testFix_ test3
@@ -27,25 +26,25 @@ all =
 -- TEST 1
 
 
-test1 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1 : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test1 =
     { description = "Test 1, replace function body of of Frontend.view"
     , src = src1
-    , rule = rule1
+    , installation = rule1
     , under = under1
     , fixed = fixed1
     , message = "Replace function \"view\""
     }
 
 
-rule1 : Rule
+rule1 : Installation
 rule1 =
-    ReplaceFunction.config
+    ReplaceFunction.replace
         "Frontend"
         "view"
         """view model =
     Html.text "This is a test\""""
-        |> ReplaceFunction.makeRule
+        |> Install.replaceFunction
 
 
 src1 : String
@@ -90,11 +89,11 @@ update msg model =
             model"""
 
 
-test1b : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1b : { description : String, src : String, installation : Installation, under : String, fixed : String, message : String }
 test1b =
     { description = "Test 1b, replace function with unformatted code"
     , src = src1b
-    , rule = rule1b
+    , installation = rule1b
     , under = under1b
     , fixed = fixed1b
     , message = "Replace function \"makeLinks\""
@@ -129,13 +128,13 @@ makeLinks model route =
         :: List.map (makeLink route) Route.routesAndNames"""
 
 
-rule1b : Rule
+rule1b : Installation
 rule1b =
-    ReplaceFunction.config
+    ReplaceFunction.replace
         "View.Main"
         "makeLinks"
         makeLinks
-        |> ReplaceFunction.makeRule
+        |> Install.replaceFunction
 
 
 under1b : String

--- a/tests/Install/ImportTest.elm
+++ b/tests/Install/ImportTest.elm
@@ -1,22 +1,22 @@
 module Install.ImportTest exposing (..)
 
 import Install.Import exposing (module_, withAlias, withExposedValues)
-import Review.Rule exposing (Rule)
-import Run
+import Install.Rule
+import Run exposing (TestData_)
 import Test exposing (Test, describe)
 
 
 all : Test
 all =
     describe "Install.Import"
-        [ Run.testFix test1
-        , Run.testFix test1a
-        , Run.testFix test2
-        , Run.testFix test3
-        , Run.testFix test4
-        , Run.expectNoErrorsTest test5.description test5.src test5.rule
-        , Run.testFix test6
-        , Run.testFix test7
+        [ Run.testFix_ test1
+        , Run.testFix_ test1a
+        , Run.testFix_ test2
+        , Run.testFix_ test3
+        , Run.testFix_ test4
+        , Run.expectNoErrorsTest_ test5.description test5.src test5.installation
+        , Run.testFix_ test6
+        , Run.testFix_ test7
         ]
 
 
@@ -24,21 +24,21 @@ all =
 -- test 1 - add simple import
 
 
-test1 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1 : TestData_
 test1 =
     { description = "add simple import"
     , src = src1
-    , rule = rule1
+    , installation = rule1
     , under = under1
     , fixed = fixed1
     , message = "add 1 import to module Main"
     }
 
 
-rule1 : Rule
+rule1 : Install.Rule.Installation
 rule1 =
     Install.Import.config "Main" [ module_ "Dict" ]
-        |> Install.Import.makeRule
+        |> Install.Rule.addImport
 
 
 src1 : String
@@ -68,11 +68,11 @@ foo = 1"""
 -- test 1a - add simple import when there are no imports
 
 
-test1a : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test1a : TestData_
 test1a =
     { description = "add simple import when there are no imports"
     , src = src1a
-    , rule = rule1
+    , installation = rule1
     , under = under1a
     , fixed = fixed1a
     , message = "add 1 import to module Main"
@@ -102,21 +102,21 @@ foo = 1"""
 -- test 2 - add import with alias
 
 
-test2 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test2 : TestData_
 test2 =
     { description = "add import with alias"
     , src = src1
-    , rule = rule2
+    , installation = rule2
     , under = under1
     , fixed = fixed2
     , message = "add 1 import to module Main"
     }
 
 
-rule2 : Rule
+rule2 : Install.Rule.Installation
 rule2 =
     Install.Import.config "Main" [ module_ "Dict" |> withAlias "D" ]
-        |> Install.Import.makeRule
+        |> Install.Rule.addImport
 
 
 fixed2 : String
@@ -132,21 +132,21 @@ foo = 1"""
 -- test 3 - add import exposing
 
 
-test3 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test3 : TestData_
 test3 =
     { description = "add import exposing"
     , src = src1
-    , rule = rule3
+    , installation = rule3
     , under = under1
     , fixed = fixed3
     , message = "add 1 import to module Main"
     }
 
 
-rule3 : Rule
+rule3 : Install.Rule.Installation
 rule3 =
     Install.Import.config "Main" [ module_ "Dict" |> withExposedValues [ "Dict" ] ]
-        |> Install.Import.makeRule
+        |> Install.Rule.addImport
 
 
 fixed3 : String
@@ -162,18 +162,18 @@ foo = 1"""
 -- Test 4 - add multiple imports with aliases and exposed values
 
 
-test4 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4 : TestData_
 test4 =
     { description = "add multiple imports with aliases and exposed values"
     , src = src1
-    , rule = rule4
+    , installation = rule4
     , under = under1
     , fixed = fixed4
     , message = "add 5 imports to module Main"
     }
 
 
-rule4 : Rule
+rule4 : Install.Rule.Installation
 rule4 =
     Install.Import.config "Main"
         [ module_ "Dict" |> withAlias "D" |> withExposedValues [ "Dict" ]
@@ -182,7 +182,7 @@ rule4 =
         , module_ "Pages.NestedModule.EvenMoreNested.MyPage" |> withAlias "MyPage"
         , module_ "Array" |> withExposedValues [ "Array" ]
         ]
-        |> Install.Import.makeRule
+        |> Install.Rule.addImport
 
 
 fixed4 : String
@@ -202,43 +202,43 @@ foo = 1"""
 -- TEST 5 - should not report an error when import already exists
 
 
-test5 : { description : String, src : String, rule : Rule }
+test5 : { description : String, src : String, installation : Install.Rule.Installation }
 test5 =
     { description = "should not report an error when import already exists"
     , src = src1
-    , rule = rule5
+    , installation = rule5
     }
 
 
-rule5 : Rule
+rule5 : Install.Rule.Installation
 rule5 =
     Install.Import.config "Main"
         [ module_ "Set" ]
-        |> Install.Import.makeRule
+        |> Install.Rule.addImport
 
 
 
 -- Test 6 - Should show correct number of imports to add when repeated imports are ignored
 
 
-test6 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test6 : TestData_
 test6 =
     { description = "Should show correct number of imports to add when repeated importes are ignored"
     , src = src1
-    , rule = rule6
+    , installation = rule6
     , under = under1
     , fixed = fixed6
     , message = "add 1 import to module Main"
     }
 
 
-rule6 : Rule
+rule6 : Install.Rule.Installation
 rule6 =
     Install.Import.config "Main"
         [ module_ "Set"
         , module_ "Dict"
         ]
-        |> Install.Import.makeRule
+        |> Install.Rule.addImport
 
 
 fixed6 : String
@@ -250,20 +250,20 @@ import Dict
 foo = 1"""
 
 
-test7 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test7 : TestData_
 test7 =
     { description = "Should show correct number of imports to add when repeated imports are ignored"
     , src = src1
-    , rule = rule7
+    , installation = rule7
     , under = under1
     , fixed = fixed7
     , message = "add 2 imports to module Main" --"Add Set and Dict to module Main using initSimple"
     }
 
 
-rule7 : Rule
+rule7 : Install.Rule.Installation
 rule7 =
-    Install.Import.qualified "Main" [ "Set", "Dict", "Foo.Bar" ] |> Install.Import.makeRule
+    Install.Import.qualified "Main" [ "Set", "Dict", "Foo.Bar" ] |> Install.Rule.addImport
 
 
 fixed7 : String

--- a/tests/Install/ImportTest.elm
+++ b/tests/Install/ImportTest.elm
@@ -2,8 +2,9 @@ module Install.ImportTest exposing (..)
 
 import Install.Import exposing (module_, withAlias, withExposedValues)
 import Install.Rule
+import Review.Test
 import Run exposing (TestData_)
-import Test exposing (Test, describe)
+import Test exposing (Test, describe, test)
 
 
 all : Test
@@ -17,6 +18,15 @@ all =
         , Run.expectNoErrorsTest_ test5.description test5.src test5.installation
         , Run.testFix_ test6
         , Run.testFix_ test7
+        , test "should not report an error when it's not the target module" <|
+            \() ->
+                """module NotMain exposing (..)
+
+import Set
+
+foo = 1"""
+                    |> Review.Test.run (Install.Rule.rule "TestRule" [ rule1 ])
+                    |> Review.Test.expectNoErrors
         ]
 
 

--- a/tests/Install/ImportTest.elm
+++ b/tests/Install/ImportTest.elm
@@ -1,7 +1,7 @@
 module Install.ImportTest exposing (..)
 
+import Install
 import Install.Import exposing (module_, withAlias, withExposedValues)
-import Install.Rule
 import Review.Test
 import Run exposing (TestData_)
 import Test exposing (Test, describe, test)
@@ -25,7 +25,7 @@ all =
 import Set
 
 foo = 1"""
-                    |> Review.Test.run (Install.Rule.rule "TestRule" [ rule1 ])
+                    |> Review.Test.run (Install.rule "TestRule" [ rule1 ])
                     |> Review.Test.expectNoErrors
         ]
 
@@ -45,10 +45,10 @@ test1 =
     }
 
 
-rule1 : Install.Rule.Installation
+rule1 : Install.Installation
 rule1 =
     Install.Import.config "Main" [ module_ "Dict" ]
-        |> Install.Rule.addImport
+        |> Install.addImport
 
 
 src1 : String
@@ -123,10 +123,10 @@ test2 =
     }
 
 
-rule2 : Install.Rule.Installation
+rule2 : Install.Installation
 rule2 =
     Install.Import.config "Main" [ module_ "Dict" |> withAlias "D" ]
-        |> Install.Rule.addImport
+        |> Install.addImport
 
 
 fixed2 : String
@@ -153,10 +153,10 @@ test3 =
     }
 
 
-rule3 : Install.Rule.Installation
+rule3 : Install.Installation
 rule3 =
     Install.Import.config "Main" [ module_ "Dict" |> withExposedValues [ "Dict" ] ]
-        |> Install.Rule.addImport
+        |> Install.addImport
 
 
 fixed3 : String
@@ -183,7 +183,7 @@ test4 =
     }
 
 
-rule4 : Install.Rule.Installation
+rule4 : Install.Installation
 rule4 =
     Install.Import.config "Main"
         [ module_ "Dict" |> withAlias "D" |> withExposedValues [ "Dict" ]
@@ -192,7 +192,7 @@ rule4 =
         , module_ "Pages.NestedModule.EvenMoreNested.MyPage" |> withAlias "MyPage"
         , module_ "Array" |> withExposedValues [ "Array" ]
         ]
-        |> Install.Rule.addImport
+        |> Install.addImport
 
 
 fixed4 : String
@@ -212,7 +212,7 @@ foo = 1"""
 -- TEST 5 - should not report an error when import already exists
 
 
-test5 : { description : String, src : String, installation : Install.Rule.Installation }
+test5 : { description : String, src : String, installation : Install.Installation }
 test5 =
     { description = "should not report an error when import already exists"
     , src = src1
@@ -220,11 +220,11 @@ test5 =
     }
 
 
-rule5 : Install.Rule.Installation
+rule5 : Install.Installation
 rule5 =
     Install.Import.config "Main"
         [ module_ "Set" ]
-        |> Install.Rule.addImport
+        |> Install.addImport
 
 
 
@@ -242,13 +242,13 @@ test6 =
     }
 
 
-rule6 : Install.Rule.Installation
+rule6 : Install.Installation
 rule6 =
     Install.Import.config "Main"
         [ module_ "Set"
         , module_ "Dict"
         ]
-        |> Install.Rule.addImport
+        |> Install.addImport
 
 
 fixed6 : String
@@ -271,9 +271,9 @@ test7 =
     }
 
 
-rule7 : Install.Rule.Installation
+rule7 : Install.Installation
 rule7 =
-    Install.Import.qualified "Main" [ "Set", "Dict", "Foo.Bar" ] |> Install.Rule.addImport
+    Install.Import.qualified "Main" [ "Set", "Dict", "Foo.Bar" ] |> Install.addImport
 
 
 fixed7 : String

--- a/tests/Install/InitializerCmdTest.elm
+++ b/tests/Install/InitializerCmdTest.elm
@@ -1,5 +1,6 @@
 module Install.InitializerCmdTest exposing (all)
 
+import Install
 import Install.InitializerCmd
 import Run
 import Test exposing (Test, describe)
@@ -8,8 +9,8 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.Initializer"
-        [ Run.testFix test1
-        , Run.expectNoErrorsTest test2.description test2.src test2.rule
+        [ Run.testFix_ test1
+        , Run.expectNoErrorsTest_ test2.description test2.src test2.installation
         ]
 
 
@@ -23,7 +24,9 @@ init =
     , Cmd.none
     )
 """
-    , rule = Install.InitializerCmd.makeRule "Client" "init" [ "Task.perform GotFastTick", "Helper.getAtmosphericRandomNumbers" ]
+    , installation =
+        Install.InitializerCmd.config "Client" "init" [ "Task.perform GotFastTick", "Helper.getAtmosphericRandomNumbers" ]
+            |> Install.initializerCmd
     , under = """init =
     ( { age = 30
       }
@@ -48,7 +51,9 @@ init =
 test2 =
     { description = "should not report an error when the field already exists"
     , src = test1.fixed
-    , rule = Install.InitializerCmd.makeRule "Client" "init" [ "Task.perform GotFastTick", "Helper.getAtmosphericRandomNumbers" ]
+    , installation =
+        Install.InitializerCmd.config "Client" "init" [ "Task.perform GotFastTick", "Helper.getAtmosphericRandomNumbers" ]
+            |> Install.initializerCmd
     }
 
 

--- a/tests/Install/InitializerTest.elm
+++ b/tests/Install/InitializerTest.elm
@@ -1,5 +1,6 @@
 module Install.InitializerTest exposing (all)
 
+import Install
 import Install.Initializer
 import Run
 import Test exposing (Test, describe)
@@ -8,11 +9,11 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.Initializer"
-        [ Run.testFix test1
-        , Run.testFix test2
-        , Run.testFix test3
-        , Run.testFix test4
-        , Run.testFix test5
+        [ Run.testFix_ test1
+        , Run.testFix_ test2
+        , Run.testFix_ test3
+        , Run.testFix_ test4
+        , Run.testFix_ test5
         ]
 
 
@@ -26,7 +27,9 @@ init =
     , Cmd.none
     )
 """
-    , rule = Install.Initializer.makeRule "Client" "init" [ { field = "name", value = "\"Nancy\"" } ]
+    , installation =
+        Install.Initializer.config "Client" "init" [ { field = "name", value = "\"Nancy\"" } ]
+            |> Install.initializer
     , under = """init =
     ( { age = 30
       }
@@ -54,7 +57,9 @@ init =
     , Cmd.none
     )
 """
-    , rule = Install.Initializer.makeRule "Client" "init" [ { field = "name", value = "\"Nancy\"" }, { field = "count", value = "0" } ]
+    , installation =
+        Install.Initializer.config "Client" "init" [ { field = "name", value = "\"Nancy\"" }, { field = "count", value = "0" } ]
+            |> Install.initializer
     , under = """init =
     ( { age = 30
       }
@@ -75,7 +80,7 @@ init =
 test3 =
     { description = "should insert a field in a function with multiple arguments"
     , src = src3
-    , rule = rule3
+    , installation = rule3
     , under = under3
     , fixed = fixed3
     , message = "Add fields to the model"
@@ -147,7 +152,8 @@ init url key =
 
 
 rule3 =
-    Install.Initializer.makeRule "Frontend" "init" [ { field = "authFlow", value = "Auth.Common.Idle" } ]
+    Install.Initializer.config "Frontend" "init" [ { field = "authFlow", value = "Auth.Common.Idle" } ]
+        |> Install.initializer
 
 
 fixed3 =
@@ -237,7 +243,7 @@ under3 =
 test4 =
     { description = "should insert multiple fields in a function with multiple arguments"
     , src = src4
-    , rule = rule4
+    , installation = rule4
     , under = under4
     , fixed = fixed4
     , message = "Add fields to the model"
@@ -245,12 +251,13 @@ test4 =
 
 
 rule4 =
-    Install.Initializer.makeRule "Backend"
+    Install.Initializer.config "Backend"
         "init"
         [ { field = "pendingAuths", value = "Dict.empty" }
         , { field = "sessions", value = "Dict.empty" }
         , { field = "users", value = "Dict.empty" }
         ]
+        |> Install.initializer
 
 
 src4 =
@@ -286,7 +293,7 @@ init =
 test5 =
     { description = "should insert multiple fields in a function with multiple arguments 2"
     , src = src5
-    , rule = rule5
+    , installation = rule5
     , under = under5
     , fixed = fixed5
     , message = "Add fields to the model"
@@ -336,12 +343,13 @@ updateFromFrontend sessionId clientId msg model =
 
 
 rule5 =
-    Install.Initializer.makeRule "Backend"
+    Install.Initializer.config "Backend"
         "init"
         [ { field = "pendingAuths", value = "Dict.empty" }
         , { field = "sessions", value = "Dict.empty" }
         , { field = "users", value = "Dict.empty" }
         ]
+        |> Install.initializer
 
 
 under5 =

--- a/tests/Install/SubTest.elm
+++ b/tests/Install/SubTest.elm
@@ -1,5 +1,6 @@
 module Install.SubTest exposing (..)
 
+import Install
 import Install.Subscription
 import Run
 import Test exposing (Test, describe)
@@ -8,9 +9,9 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.Initializer"
-        [ Run.testFix test1
-        , Run.expectNoErrorsTest test2.description test2.src test2.rule
-        , Run.testFix test3
+        [ Run.testFix_ test1
+        , Run.expectNoErrorsTest_ test2.description test2.src test2.installation
+        , Run.testFix_ test3
         ]
 
 
@@ -21,7 +22,9 @@ test1 =
 subscriptions model =
   Sub.batch [ foo model ]
 """
-    , rule = Install.Subscription.makeRule "Backend" [ "bar model" ]
+    , installation =
+        Install.Subscription.config "Backend" [ "bar model" ]
+            |> Install.subscription
     , under = """subscriptions"""
     , fixed = """module Backend exposing (..)
 
@@ -39,7 +42,9 @@ test2 =
 subscriptions model =
   Sub.batch [ foo model, bar model ]
 """
-    , rule = Install.Subscription.makeRule "Backend" [ "bar model" ]
+    , installation =
+        Install.Subscription.config "Backend" [ "bar model" ]
+            |> Install.subscription
     }
 
 
@@ -54,7 +59,9 @@ test3 =
 subscriptions model =
   Sub.batch [ foo model ]
 """
-    , rule = Install.Subscription.makeRule "Backend" [ "bar model", "baz model" ]
+    , installation =
+        Install.Subscription.config "Backend" [ "bar model", "baz model" ]
+            |> Install.subscription
     , under = """subscriptions"""
     , fixed = """module Backend exposing (..)
 

--- a/tests/Install/TypeVariantTest.elm
+++ b/tests/Install/TypeVariantTest.elm
@@ -1,5 +1,6 @@
 module Install.TypeVariantTest exposing (all)
 
+import Install
 import Install.TypeVariant
 import Run
 import Test exposing (Test, describe)
@@ -8,15 +9,15 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.TypeVariant"
-        [ Run.testFix test1
-        , Run.testFix test2
+        [ Run.testFix_ test1
+        , Run.testFix_ test2
         ]
 
 
 test1 =
     { description = "should report an error when the variant does not exist"
     , src = src1
-    , rule = rule1
+    , installation = rule1
     , under = under1
     , fixed = fixed1
     , message = "Add variants [Admin, Assistant] to Role"
@@ -26,7 +27,7 @@ test1 =
 test2 =
     { description = "should report an error when the variant does not exist in nested module"
     , src = src2
-    , rule = rule2
+    , installation = rule2
     , under = under2
     , fixed = fixed2
     , message = "Add variants [TO] to BrazilianStates"
@@ -34,7 +35,8 @@ test2 =
 
 
 rule1 =
-    Install.TypeVariant.makeRule "User" "Role" [ "Admin", "Assistant Int" ]
+    Install.TypeVariant.config "User" "Role" [ "Admin", "Assistant Int" ]
+        |> Install.addTypeVariant
 
 
 src1 =
@@ -59,7 +61,8 @@ type Role
 
 
 rule2 =
-    Install.TypeVariant.makeRule "Data.States" "BrazilianStates" [ "TO" ]
+    Install.TypeVariant.config "Data.States" "BrazilianStates" [ "TO" ]
+        |> Install.addTypeVariant
 
 
 src2 =

--- a/tests/Run.elm
+++ b/tests/Run.elm
@@ -28,7 +28,7 @@ expectNoErrorsTest_ description src installation =
     test description <|
         \() ->
             src
-                |> Review.Test.run (Install.Rule.rule [ installation ])
+                |> Review.Test.run (Install.Rule.rule "TestRule" [ installation ])
                 |> Review.Test.expectNoErrors
 
 
@@ -83,7 +83,7 @@ testFix_ { description, src, installation, under, fixed, message } =
     test description <|
         \() ->
             src
-                |> Review.Test.run (Install.Rule.rule [ installation ])
+                |> Review.Test.run (Install.Rule.rule "TestRule" [ installation ])
                 |> Review.Test.expectErrors
                     [ Review.Test.error { message = message, details = [ "" ], under = under }
                         |> Review.Test.whenFixed fixed

--- a/tests/Run.elm
+++ b/tests/Run.elm
@@ -33,12 +33,12 @@ expectNoErrorsTest_ description src installation =
                 |> Review.Test.expectNoErrors
 
 
-expectErrorsTest : String -> String -> Rule -> Test
-expectErrorsTest description src rule =
+expectErrorsTest : String -> String -> Install.Installation -> Test
+expectErrorsTest description src installation =
     test description <|
         \() ->
             src
-                |> Review.Test.run rule
+                |> Review.Test.run (Install.rule "TestRule" [ installation ])
                 |> Review.Test.expectErrors []
 
 

--- a/tests/Run.elm
+++ b/tests/Run.elm
@@ -1,5 +1,6 @@
 module Run exposing
-    ( TestData_
+    ( TestData
+    , TestData_
     , expectErrorsTest
     , expectNoErrorsTest
     , expectNoErrorsTest_

--- a/tests/Run.elm
+++ b/tests/Run.elm
@@ -1,11 +1,14 @@
 module Run exposing
-    ( expectErrorsTest
+    ( TestData_
+    , expectErrorsTest
     , expectNoErrorsTest
     , expectNoErrorsTest_
     , testFix
+    , testFix_
     , withOnly
     )
 
+import Install.Rule
 import Review.Rule exposing (Rule)
 import Review.Test
 import Test exposing (Test, test)
@@ -20,12 +23,12 @@ expectNoErrorsTest description src rule =
                 |> Review.Test.expectNoErrors
 
 
-expectNoErrorsTest_ : TestData -> Test
-expectNoErrorsTest_ testData =
-    test testData.description <|
+expectNoErrorsTest_ : String -> String -> Install.Rule.Installation -> Test
+expectNoErrorsTest_ description src installation =
+    test description <|
         \() ->
-            testData.src
-                |> Review.Test.run testData.rule
+            src
+                |> Review.Test.run (Install.Rule.rule [ installation ])
                 |> Review.Test.expectNoErrors
 
 
@@ -59,6 +62,28 @@ testFix { description, src, rule, under, fixed, message } =
         \() ->
             src
                 |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ Review.Test.error { message = message, details = [ "" ], under = under }
+                        |> Review.Test.whenFixed fixed
+                    ]
+
+
+type alias TestData_ =
+    { description : String
+    , src : String
+    , installation : Install.Rule.Installation
+    , under : String
+    , fixed : String
+    , message : String
+    }
+
+
+testFix_ : TestData_ -> Test
+testFix_ { description, src, installation, under, fixed, message } =
+    test description <|
+        \() ->
+            src
+                |> Review.Test.run (Install.Rule.rule [ installation ])
                 |> Review.Test.expectErrors
                     [ Review.Test.error { message = message, details = [ "" ], under = under }
                         |> Review.Test.whenFixed fixed

--- a/tests/Run.elm
+++ b/tests/Run.elm
@@ -8,7 +8,7 @@ module Run exposing
     , withOnly
     )
 
-import Install.Rule
+import Install
 import Review.Rule exposing (Rule)
 import Review.Test
 import Test exposing (Test, test)
@@ -23,12 +23,12 @@ expectNoErrorsTest description src rule =
                 |> Review.Test.expectNoErrors
 
 
-expectNoErrorsTest_ : String -> String -> Install.Rule.Installation -> Test
+expectNoErrorsTest_ : String -> String -> Install.Installation -> Test
 expectNoErrorsTest_ description src installation =
     test description <|
         \() ->
             src
-                |> Review.Test.run (Install.Rule.rule "TestRule" [ installation ])
+                |> Review.Test.run (Install.rule "TestRule" [ installation ])
                 |> Review.Test.expectNoErrors
 
 
@@ -71,7 +71,7 @@ testFix { description, src, rule, under, fixed, message } =
 type alias TestData_ =
     { description : String
     , src : String
-    , installation : Install.Rule.Installation
+    , installation : Install.Installation
     , under : String
     , fixed : String
     , message : String
@@ -83,7 +83,7 @@ testFix_ { description, src, installation, under, fixed, message } =
     test description <|
         \() ->
             src
-                |> Review.Test.run (Install.Rule.rule "TestRule" [ installation ])
+                |> Review.Test.run (Install.rule "TestRule" [ installation ])
                 |> Review.Test.expectErrors
                     [ Review.Test.error { message = message, details = [ "" ], under = under }
                         |> Review.Test.whenFixed fixed


### PR DESCRIPTION
Hi @jxxcarlson @mateusfpleite

This PR makes it so that every single transformation is not a rule in itself but can be combined into a rule. This makes it possible - or at least easier - to run only a single transformation, without needing to create a whole new project. That makes it easier to run rules from a template.

```bash
elm-review --template --fix-all author/package/lamdera --rules AddAuth
```

(and you can **still** create multiple templates if you'd like to, both become possible).

It is **absolutely fine** for you to dismiss this PR/idea, if you think this is a bad idea. I had a bit of fun doing it anyway.

This includes a few bits of cleanup I did prior to the larger API changes. Some are already of note, like stopping the exposing of `CustomError` which was unnecessary, and that is technically a breaking change. I enabled a few `elm-review` rules that should help identify issues related to docs and things not being exposed when they should (that wouldn't have caught `CustomError` though).

---

Note: I made this PR inside of my fork because it's based off of https://github.com/jxxcarlson/elm-review-codeinstaller/pull/49, but I wanted to get the conversation going. I'll re-do the PR once it's merged (though I think that will lose the comments...).

---

The API and documentation very likely need a bit of polish. I may have missed updating some documentation, but they APIs could probably be made nicer to use. It's likely a bad idea to publish a new version right after this gets merged.

A few ideas (for which I'd like feedback):
- Rename `Installation` to something else that makes more sense. I chose it to get going, but I'm not attached to the name.
- Name every configuration function `config`. By the end of the change, I named every function `config` (`Initializer.config`, ...) but for the first ones I gave them different names, such as `ElementToList.add`. I think we could name them all `config` for consistency, although that would make `AddImport.qualified` look out of place.

---

Another idea, which could probably be a bit simpler, is to group installations per module, rather than passing the module name to every single installation. That could look something like this:

```elm
config = List Rule
config =
    [ Install.rule "AddPage"
        [ ( "ViewMain"
          , [ Import.qualified [ "Pages." ++ pageTitle ]
              |> Install.Rule.addImport
            -- , ...
            ]
          )
        , ( "Route"
          , [ ElementToList.add "routesAndNames"
                [ "(" ++ pageTitle ++ "Route, \"" ++ routeName ++ "\")" ]
                |> Install.Rule.addElementToList
            -- ...
            ]
          )
        ]
    ]
```